### PR TITLE
chore: replace enechange references with iwamot

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -8,7 +8,7 @@ jobs:
     timeout-minutes: 5
     permissions:
       pull-requests: write
-    if: github.event.pull_request.user.login == 'enechange-renovate[bot]'
+    if: github.event.pull_request.user.login == 'iwamot-renovate[bot]'
     steps:
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:

--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,7 @@ The MIT License (MIT)
 
 Copyright (c) Slack Technologies, LLC
 Copyright (c) 2024 ENECHANGE Ltd.
+Copyright (c) 2026 Takashi Iwamoto
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@
 
 # Collmbo
 
-[![CI](https://github.com/enechange/collmbo/actions/workflows/ci.yml/badge.svg)](https://github.com/enechange/collmbo/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/enechange/collmbo/branch/main/graph/badge.svg)](https://app.codecov.io/gh/enechange/collmbo)
+[![CI](https://github.com/iwamot/collmbo/actions/workflows/ci.yml/badge.svg)](https://github.com/iwamot/collmbo/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/iwamot/collmbo/branch/main/graph/badge.svg)](https://app.codecov.io/gh/iwamot/collmbo)
 
 ![Collmbo icon](https://github.com/user-attachments/assets/b13da1c7-5d2f-4ad3-8c5b-9ef4e500deb8)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,4 +8,4 @@ This software is provided "as is" without warranty. Security issues will be addr
 
 Please report security vulnerabilities through GitHub's Security Advisory "Report a Vulnerability" feature.
 
-https://github.com/enechange/collmbo/security/advisories/new
+https://github.com/iwamot/collmbo/security/advisories/new

--- a/docs/features/custom-callbacks.md
+++ b/docs/features/custom-callbacks.md
@@ -19,7 +19,7 @@ OPENAI_API_KEY=sk-...
 LLM_MODEL=gpt-5.2
 LITELLM_CALLBACK_MODULE_NAME=examples.callback_handler
 
-$ docker run -it --env-file ./env -v ./examples:/app/examples ghcr.io/enechange/collmbo:latest
+$ docker run -it --env-file ./env -v ./examples:/app/examples ghcr.io/iwamot/collmbo:latest
 ```
 
 > ![Custom callbacks example](https://github.com/user-attachments/assets/38a83ac9-1429-46ad-bd6c-95e1d6aac247)

--- a/docs/features/image-input.md
+++ b/docs/features/image-input.md
@@ -15,7 +15,7 @@ OPENAI_API_KEY=sk-...
 LLM_MODEL=gpt-5.2
 IMAGE_INPUT_ENABLED=true
 
-$ docker run -it --env-file ./env ghcr.io/enechange/collmbo:latest
+$ docker run -it --env-file ./env ghcr.io/iwamot/collmbo:latest
 ```
 
 > ![Image input example](https://github.com/user-attachments/assets/41e11441-230e-41db-8cae-efe5fd9dd426)

--- a/docs/features/mcp-tools.md
+++ b/docs/features/mcp-tools.md
@@ -68,7 +68,7 @@ LLM_MODEL=gpt-5.2
 AWS_ACCESS_KEY_ID=...
 AWS_SECRET_ACCESS_KEY=...
 
-$ docker run -it --env-file ./env -v ./config:/app/config ghcr.io/enechange/collmbo:latest
+$ docker run -it --env-file ./env -v ./config:/app/config ghcr.io/iwamot/collmbo:latest
 ```
 
 `workload_name` will be used as a name for [AgentCore Identity workload](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/creating-agent-identities.html).

--- a/docs/features/pdf-input.md
+++ b/docs/features/pdf-input.md
@@ -15,7 +15,7 @@ OPENAI_API_KEY=sk-...
 LLM_MODEL=bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0
 PDF_INPUT_ENABLED=true
 
-$ docker run -it --env-file ./env ghcr.io/enechange/collmbo:latest
+$ docker run -it --env-file ./env ghcr.io/iwamot/collmbo:latest
 ```
 
 > ![PDF input example](https://github.com/user-attachments/assets/181a5400-3d6c-4daf-aa64-7d7cdd4cfaee)

--- a/docs/features/prompt-caching.md
+++ b/docs/features/prompt-caching.md
@@ -12,7 +12,7 @@ ANTHROPIC_API_KEY=sk-ant-...
 LLM_MODEL=claude-3-7-sonnet-20250219
 PROMPT_CACHING_ENABLED=true
 
-$ docker run -it --env-file ./env ghcr.io/enechange/collmbo:latest
+$ docker run -it --env-file ./env ghcr.io/iwamot/collmbo:latest
 ```
 
 When enabled, cache breakpoints will automatically be added to **the two most recent user messages** when the total context size is 1,024 tokens or more. This may help reduce API costs.

--- a/docs/features/redaction.md
+++ b/docs/features/redaction.md
@@ -20,7 +20,7 @@ REDACT_USER_DEFINED_PATTERN=\bsensitive string\b
 # Here, logging is enabled to check the effect of redaction
 LITELLM_CALLBACK_MODULE_NAME=examples.callback_handler
 
-$ docker run -it --env-file ./env -v ./examples:/app/examples ghcr.io/enechange/collmbo:latest
+$ docker run -it --env-file ./env -v ./examples:/app/examples ghcr.io/iwamot/collmbo:latest
 ```
 
 Sensitive strings in the message will be masked before being sent to the model.

--- a/docs/features/slack-friendly-formatting.md
+++ b/docs/features/slack-friendly-formatting.md
@@ -12,7 +12,7 @@ OPENAI_API_KEY=sk-...
 LLM_MODEL=gpt-5.2
 SLACK_FORMATTING_ENABLED=true
 
-$ docker run -it --env-file ./env ghcr.io/enechange/collmbo:latest
+$ docker run -it --env-file ./env ghcr.io/iwamot/collmbo:latest
 ```
 
 > ![Slack formatting example](https://github.com/user-attachments/assets/6d73ed53-2849-4370-acb3-62694c05f86f)

--- a/docs/features/tools-function-calling.md
+++ b/docs/features/tools-function-calling.md
@@ -19,7 +19,7 @@ OPENAI_API_KEY=sk-...
 LLM_MODEL=gpt-5.2
 TOOLS_MODULE_NAME=examples.tools
 
-$ docker run -it --env-file ./env -v ./examples:/app/examples ghcr.io/enechange/collmbo:latest
+$ docker run -it --env-file ./env -v ./examples:/app/examples ghcr.io/iwamot/collmbo:latest
 ```
 
 > ![Tools example](https://github.com/user-attachments/assets/d48a44fd-56fa-43c7-a0de-567ba03088b5)


### PR DESCRIPTION
## Summary

Migrate repository references from enechange to iwamot. The project was originally developed under the iwamot account, then transferred to enechange. Development continues on the iwamot fork.

- Replace `ghcr.io/enechange/collmbo` with `ghcr.io/iwamot/collmbo` in feature docs
- Update SECURITY.md advisory URL to iwamot/collmbo
- Add Takashi Iwamoto copyright to LICENSE
- Update auto-approve.yml bot name to `iwamot-renovate[bot]`
- Update CI and Codecov badge URLs in README.md

🤖 Generated with [Claude Code](https://claude.ai/code)