### PR TITLE
chore(deps): update Trivy to v0.69.3

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -42,7 +42,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           scanners: 'vuln'
-          version: 'v0.68.2'
+          version: 'v0.69.3'
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1


### PR DESCRIPTION
## Summary

- Update Trivy from v0.68.2 to v0.69.3
- v0.68.2 binaries were removed from GitHub Releases due to the supply chain attack (GHSA-69fq-xp46-6x23)
- v0.69.3 is an officially recommended safe version, compatible with the current trivy-action pin

🤖 Generated with [Claude Code](https://claude.ai/code)