### PR TITLE
chore: switch Renovate to Takumi Guard registry in lock files

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -52,6 +52,7 @@ jobs:
           configurationFile: .github/renovate.json
           token: ${{ steps.app-token.outputs.token }}
         env:
+          PIP_INDEX_URL: https://pypi.flatt.tech/simple/
           LOG_LEVEL: ${{ inputs.log-level || 'info' }}
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_HOST_RULES: '[{"matchHost":"dhi.io","hostType":"docker","username":"${{ secrets.DOCKERHUB_USERNAME }}","password":"${{ secrets.DOCKERHUB_TOKEN }}"}]'


### PR DESCRIPTION
## Summary
- Pass `PIP_INDEX_URL` to Renovate so that `uv lock` uses Takumi Guard registry
- Ensures lock file URLs are consistent with local development and CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)