### PR TITLE
chore: set Takumi Guard as default uv index in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,10 @@ dev = [
     "pytest-cov==7.1.0",
 ]
 
+[[tool.uv.index]]
+url = "https://pypi.flatt.tech/simple/"
+default = true
+
 [tool.ruff]
 include = ["*.py", "app/**/*.py", "tests/**/*.py"]
 


### PR DESCRIPTION
## Summary
- Configure `pypi.flatt.tech` as the default index in `pyproject.toml` via `[[tool.uv.index]]`
- Ensures consistent lock file URLs across local, CI, Renovate, and Docker environments
- Eliminates dependency on environment variables for index URL configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)