### PR TITLE
chore: add OIDC authentication to Takumi Guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: production
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout code
@@ -24,6 +27,8 @@ jobs:
 
       - name: Setup Takumi Guard
         uses: flatt-security/setup-takumi-guard-pypi@7d825811bb293b9e0230477165442580a0074280 # v1.0.0
+        with:
+          bot-id: BT01KN64BM5NBFHJNSSDYQWKE279
 
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -23,6 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: production
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -31,6 +34,8 @@ jobs:
 
       - name: Setup Takumi Guard
         uses: flatt-security/setup-takumi-guard-pypi@7d825811bb293b9e0230477165442580a0074280 # v1.0.0
+        with:
+          bot-id: BT01KN64BM5NBFHJNSSDYQWKE279
 
       - name: Generate GitHub App token
         id: app-token


### PR DESCRIPTION
## Summary

- Add OIDC authentication (bot-id) to Takumi Guard in CI and Renovate workflows
- Relaxes rate limits by 5x compared to anonymous mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)