### PR TITLE
chore: minimumReleaseAge for PyPI packages and uv

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,6 +25,17 @@
       "depNameTemplate": "astral-sh/uv",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v?(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/Dockerfile$/"
+      ],
+      "matchStrings": [
+        "pip install uv==(?<currentValue>[^\\s]+)"
+      ],
+      "depNameTemplate": "uv",
+      "datasourceTemplate": "pypi"
     }
   ],
   "packageRules": [
@@ -34,6 +45,16 @@
         "mise"
       ],
       "groupName": "mise-tools"
+    },
+    {
+      "description": "Use PyPI for release timestamp metadata",
+      "matchDatasources": [
+        "pypi"
+      ],
+      "registryUrls": [
+        "https://pypi.org/pypi/",
+        "https://pypi.flatt.tech/simple/"
+      ]
     },
     {
       "description": "Group Python dependencies",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM dhi.io/python:3.14.3-debian13-dev@sha256:5e79fe77bdf98210f443d4a79fc87ad2c4da3e7047432752ba0a38094ac3b6fa AS builder
 WORKDIR /build/
-COPY --from=ghcr.io/astral-sh/uv:0.11.2@sha256:c4f5de312ee66d46810635ffc5df34a1973ba753e7241ce3a08ef979ddd7bea5 /uv /usr/local/bin/uv
+RUN pip install --no-cache-dir uv==0.11.3
 COPY pyproject.toml uv.lock /build/
 RUN uv sync --frozen --no-dev
 


### PR DESCRIPTION
## Summary

- Fix release timestamp not being fetched from pypi.flatt.tech for PyPI packages
- Change uv installation in Dockerfile from Docker image copy to pip install

🤖 Generated with [Claude Code](https://claude.com/claude-code)