### PR TITLE
chore: enable vulnerability alerts and disable lockFileMaintenance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,14 @@
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
   "minimumReleaseAge": "3 days",
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "minimumReleaseAge": null,
+    "automerge": true
+  },
+  "lockFileMaintenance": {
+    "enabled": false
+  },
   "constraints": {
     "uv": "0.11.3"
   },
@@ -78,20 +86,18 @@
       "groupName": "github-actions"
     },
     {
-      "description": "Disable minimumReleaseAge for digest and lockFileMaintenance",
+      "description": "Disable minimumReleaseAge for digest updates",
       "matchUpdateTypes": [
-        "digest",
-        "lockFileMaintenance"
+        "digest"
       ],
       "minimumReleaseAge": null
     },
     {
-      "description": "Automerge minor, patch, digest, and lockFileMaintenance updates",
+      "description": "Automerge minor, patch, and digest updates",
       "matchUpdateTypes": [
         "minor",
         "patch",
-        "digest",
-        "lockFileMaintenance"
+        "digest"
       ],
       "automerge": true
     },


### PR DESCRIPTION
## Summary

- Enable `vulnerabilityAlerts` with automerge for immediate security fixes
- Disable `lockFileMaintenance` to avoid unverified transitive dependency updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)