### PR TITLE
chore: remove temporary trivy-action disable rule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -100,13 +100,6 @@
         "digest"
       ],
       "automerge": true
-    },
-    {
-      "description": "Temporarily disable trivy-action due to supply chain attack aftermath",
-      "matchPackageNames": [
-        "aquasecurity/trivy-action"
-      ],
-      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Remove the temporary Renovate rule that disabled trivy-action updates
- The supply chain attack aftermath has been resolved
- Current version (0.35.0) is already the latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)