### PR TITLE
chore: disable Renovate grouping and add release date to PR title

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -48,11 +48,14 @@
   ],
   "packageRules": [
     {
-      "description": "Group mise tools updates",
-      "matchManagers": [
-        "mise"
-      ],
-      "groupName": "mise-tools"
+      "description": "Disable all grouping",
+      "matchPackageNames": ["*"],
+      "groupName": null
+    },
+    {
+      "description": "Add release date to PR title if available",
+      "matchPackageNames": ["*"],
+      "commitMessageExtra": "{{#if releaseTimestamp}}({{{replace 'T.*' '' releaseTimestamp}}}){{/if}}"
     },
     {
       "description": "Use PyPI for release timestamp metadata",
@@ -63,27 +66,6 @@
         "https://pypi.org/pypi/",
         "https://pypi.flatt.tech/simple/"
       ]
-    },
-    {
-      "description": "Group Python dependencies",
-      "matchManagers": [
-        "pep621"
-      ],
-      "groupName": "python-dependencies"
-    },
-    {
-      "description": "Group Dockerfile updates",
-      "matchManagers": [
-        "dockerfile"
-      ],
-      "groupName": "dockerfile"
-    },
-    {
-      "description": "Group GitHub Actions updates",
-      "matchManagers": [
-        "github-actions"
-      ],
-      "groupName": "github-actions"
     },
     {
       "description": "Disable minimumReleaseAge for digest updates",


### PR DESCRIPTION
## Summary

- Disable all grouping to create individual PRs per package
- Add release date to PR title when `releaseTimestamp` is available (e.g., `Update hono to 4.7.10 (2025-04-05)`)
- Reorder packageRules for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)