### PR TITLE
chore: use dhi.io/uv image instead of pip install

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -33,17 +33,6 @@
       "depNameTemplate": "astral-sh/uv",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v?(?<version>.+)$"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/Dockerfile$/"
-      ],
-      "matchStrings": [
-        "pip install uv==(?<currentValue>[^\\s]+)"
-      ],
-      "depNameTemplate": "uv",
-      "datasourceTemplate": "pypi"
     }
   ],
   "packageRules": [

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM dhi.io/python:3.14.3-debian13-dev@sha256:de13b64e07a18bf0116a245c1ffcb1a5ef5cd6413eaf5568b9ea23be08e710ff AS builder
 WORKDIR /build/
-RUN pip install --no-cache-dir uv==0.11.3
+COPY --from=dhi.io/uv:0.11.3-debian13-dev /uv /usr/local/bin/uv
 COPY pyproject.toml uv.lock /build/
 RUN uv sync --frozen --no-dev
 


### PR DESCRIPTION
## Summary
- Switch from `pip install uv` to `COPY --from=dhi.io/uv` for better security and trust consistency with other dhi.io images
- Remove the pip-based customManager from renovate.json (Renovate's dockerfile manager handles COPY --from natively)

🤖 Generated with [Claude Code](https://claude.ai/code)