### PR TITLE
chore: add pinDigest to automerge and minimumReleaseAge rules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -57,18 +57,20 @@
       ]
     },
     {
-      "description": "Disable minimumReleaseAge for digest updates",
+      "description": "Disable minimumReleaseAge for digest and pinDigest updates",
       "matchUpdateTypes": [
-        "digest"
+        "digest",
+        "pinDigest"
       ],
       "minimumReleaseAge": null
     },
     {
-      "description": "Automerge minor, patch, and digest updates",
+      "description": "Automerge minor, patch, digest, and pinDigest updates",
       "matchUpdateTypes": [
         "minor",
         "patch",
-        "digest"
+        "digest",
+        "pinDigest"
       ],
       "automerge": true
     }


### PR DESCRIPTION
## Summary
- Add `pinDigest` to `matchUpdateTypes` for minimumReleaseAge and automerge rules
- This allows initial digest pinning (like PR #33) to be automerged without the 3-day wait

🤖 Generated with [Claude Code](https://claude.ai/code)