### PR TITLE
chore: pin mise version to 2026.4.8

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,6 +26,20 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
+        "/^\\.mise\\.toml$/",
+        "/^\\.github/workflows/ci\\.yml$/"
+      ],
+      "matchStrings": [
+        "min_version\\s*=\\s*\"(?<currentValue>[^\"]+)\"",
+        "jdx/mise-action@[^\\n]*\\n\\s*with:\\s*\\n\\s*version:\\s*(?<currentValue>\\S+)"
+      ],
+      "depNameTemplate": "jdx/mise",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v?(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
         "/^\\.github/renovate\\.json$/"
       ],
       "matchStrings": [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          version: 2026.4.8
 
       - name: Run validation script
         run: bash validate.sh

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,3 +1,5 @@
+min_version = "2026.4.8"
+
 [tools]
 actionlint = "1.7.12"
 "aqua:suzuki-shunsuke/ghalint" = "1.5.5"


### PR DESCRIPTION
## Summary
- Add `min_version` to `.mise.toml` and a `version` input to the `mise-action` step so local and CI run on the same mise release.
- Extend Renovate `customManagers` to keep `.mise.toml` and `ci.yml` in sync via the `jdx/mise` GitHub releases datasource.

🤖 Generated with [Claude Code](https://claude.com/claude-code)