### PR TITLE
chore: align Renovate config with config:best-practices defaults

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,6 @@
   "labels": [
     "dependencies"
   ],
-  "rebaseWhen": "conflicted",
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
   "minimumReleaseAge": "3 days",
@@ -51,16 +50,6 @@
     }
   ],
   "packageRules": [
-    {
-      "description": "Disable all grouping",
-      "matchPackageNames": ["*"],
-      "groupName": null
-    },
-    {
-      "description": "Add release date to PR title if available",
-      "matchPackageNames": ["*"],
-      "commitMessageExtra": "{{#if releaseTimestamp}}({{{replace 'T.*' '' releaseTimestamp}}}){{/if}}"
-    },
     {
       "description": "Disable automerge for major updates",
       "matchUpdateTypes": ["major"],


### PR DESCRIPTION
## Summary

- Remove the "Disable all grouping" rule and defer to `config:best-practices` defaults (`group:monorepos` + `group:recommended`)
- Remove the PR-title release-date rule (redundant when the 3-day quarantine is the main goal)
- Remove `rebaseWhen: "conflicted"` since it matches the global default

Intended to reduce the frequency of "Automerge: Disabled because a matching PR was automerged previously." caused by per-package branch reuse, by letting Renovate's minimal default grouping do the batching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)