### PR TITLE
chore: adopt official Renovate presets

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,22 +1,19 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:best-practices"
+    "config:best-practices",
+    "customManagers:githubActionsVersions",
+    ":automergeAll",
+    ":label(dependencies)",
+    ":maintainLockFilesDisabled",
+    ":prConcurrentLimitNone",
+    ":prHourlyLimitNone"
   ],
-  "labels": [
-    "dependencies"
-  ],
-  "prHourlyLimit": 0,
-  "prConcurrentLimit": 0,
   "minimumReleaseAge": "3 days",
-  "automerge": true,
   "minimumReleaseAgeBehaviour": "timestamp-optional",
   "vulnerabilityAlerts": {
     "enabled": true,
     "minimumReleaseAge": null
-  },
-  "lockFileMaintenance": {
-    "enabled": false
   },
   "constraints": {
     "uv": "0.11.6"
@@ -24,26 +21,16 @@
   "customManagers": [
     {
       "customType": "regex",
-      "managerFilePatterns": [
-        "/^\\.mise\\.toml$/",
-        "/^\\.github/workflows/ci\\.yml$/"
-      ],
-      "matchStrings": [
-        "min_version\\s*=\\s*\"(?<currentValue>[^\"]+)\"",
-        "jdx/mise-action@[^\\n]*\\n\\s*with:\\s*\\n\\s*version:\\s*(?<currentValue>\\S+)"
-      ],
+      "managerFilePatterns": ["/^\\.mise\\.toml$/"],
+      "matchStrings": ["min_version\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "jdx/mise",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v?(?<version>.+)$"
     },
     {
       "customType": "regex",
-      "managerFilePatterns": [
-        "/^\\.github/renovate\\.json$/"
-      ],
-      "matchStrings": [
-        "\"constraints\":\\s*\\{[^}]*\"uv\":\\s*\"(?<currentValue>[^\"]+)\""
-      ],
+      "managerFilePatterns": ["/^\\.github/renovate\\.json$/"],
+      "matchStrings": ["\"constraints\":\\s*\\{[^}]*\"uv\":\\s*\"(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "astral-sh/uv",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v?(?<version>.+)$"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
     environment: production
     permissions:
       contents: read
+    env:
+      # renovate: datasource=github-releases depName=jdx/mise extractVersion=^v?(?<version>.+)$
+      MISE_VERSION: 2026.4.9
 
     steps:
       - name: Checkout code
@@ -27,7 +30,7 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          version: 2026.4.9
+          version: ${{ env.MISE_VERSION }}
 
       - name: Run validation script
         run: bash validate.sh


### PR DESCRIPTION
## Summary

- Adopt `customManagers:githubActionsVersions` to track the mise version in ci.yml via `env.MISE_VERSION`
- Replace inline settings with `:automergeAll`, `:label(dependencies)`, `:maintainLockFilesDisabled`, `:prConcurrentLimitNone`, `:prHourlyLimitNone`
- Keep the custom managers for `.mise.toml` `min_version` and the uv `constraints` field (no matching preset)

Verified locally with `renovate --dry-run` that both `jdx/mise` (ci.yml + .mise.toml) and `astral-sh/uv` are still detected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)