### PR TITLE
chore: pass uv constraint via env var

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,23 +15,12 @@
     "enabled": true,
     "minimumReleaseAge": null
   },
-  "constraints": {
-    "uv": "0.11.6"
-  },
   "customManagers": [
     {
       "customType": "regex",
       "managerFilePatterns": ["/^\\.mise\\.toml$/"],
       "matchStrings": ["min_version\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "jdx/mise",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^v?(?<version>.+)$"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^\\.github/renovate\\.json$/"],
-      "matchStrings": ["\"constraints\":\\s*\\{[^}]*\"uv\":\\s*\"(?<currentValue>[^\"]+)\""],
-      "depNameTemplate": "astral-sh/uv",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v?(?<version>.+)$"
     }

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -25,6 +25,9 @@ jobs:
     environment: production
     permissions:
       contents: read
+    env:
+      # renovate: datasource=github-releases depName=astral-sh/uv extractVersion=^v?(?<version>.+)$
+      UV_VERSION: 0.11.6
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -54,3 +57,4 @@ jobs:
           LOG_LEVEL: ${{ inputs.log-level || 'info' }}
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_HOST_RULES: '[{"matchHost":"dhi.io","hostType":"docker","username":"${{ secrets.DOCKERHUB_USERNAME }}","password":"${{ secrets.DOCKERHUB_TOKEN }}"}]'
+          RENOVATE_CONSTRAINTS: '{"uv": "${{ env.UV_VERSION }}"}'


### PR DESCRIPTION
## Summary

- Move the uv version pin from `renovate.json` `constraints` into the Renovate workflow's job-level `env.UV_VERSION`
- Pass it to Renovate via `RENOVATE_CONSTRAINTS='{"uv": "${{ env.UV_VERSION }}"}'`
- This lets `customManagers:githubActionsVersions` handle uv bumps automatically, so the custom regex manager for `astral-sh/uv` can be removed

Verified locally with `RENOVATE_CONSTRAINTS='{"uv":"0.11.6"}' npx renovate --platform=local` that the constraint is applied and `UV_VERSION` is detected via the preset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)