### PR TITLE
chore: use OIDC for Codecov upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
     environment: production
     permissions:
       contents: read
+      id-token: write
     env:
       # renovate: datasource=github-releases depName=jdx/mise extractVersion=^v?(?<version>.+)$
       MISE_VERSION: 2026.4.9
@@ -38,4 +39,4 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true


### PR DESCRIPTION
## Summary
- Switch Codecov upload from a secret-based token to tokenless OIDC.
- Reduces the risk of `CODECOV_TOKEN` being exfiltrated via a supply-chain attack on third-party actions.
- Adds `id-token: write` permission to the job and sets `use_oidc: true` on `codecov/codecov-action`.

After this is merged, the `CODECOV_TOKEN` repository secret can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)