### PR TITLE
chore: drop unused production environment from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
     name: Run Linting, Type Check, and Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    environment: production
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary
- Remove `environment: production` from the CI job.
- After the Codecov OIDC migration, the CI job no longer references any secrets, so the environment declaration is unused.
- Keeping it would cause PR runs to be blocked once the `production` environment is restricted to the `main` branch and release tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)