### PR TITLE
chore: replace deprecated app-id with client-id in create-github-app-token

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -38,7 +38,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          client-id: ${{ secrets.RENOVATE_APP_ID }}
           private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
           permission-contents: write
           permission-issues: write


### PR DESCRIPTION
## Summary

- The `app-id` input of `actions/create-github-app-token` has been deprecated; switched to `client-id`.