### PR TITLE
chore: split mise min_version into hard and soft

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,7 +19,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": ["/^\\.mise\\.toml$/"],
-      "matchStrings": ["min_version\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
+      "matchStrings": ["soft\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "jdx/mise",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v?(?<version>.+)$"

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,4 +1,4 @@
-min_version = "2026.4.9"
+min_version = { hard = "2026.4.8", soft = "2026.4.9" }
 
 [tools]
 actionlint = "1.7.12"


### PR DESCRIPTION
## Summary
- Switch \`min_version\` in \`.mise.toml\` to the object form with \`hard\` and \`soft\`.
- \`hard = 2026.4.8\` keeps the real compatibility floor (the version where the current config was last known to fail below).
- \`soft = 2026.4.9\` is the recommended version that Renovate will continue to bump.
- Narrow the custom regex manager to match only \`soft\` so Renovate updates recommendations without touching the hard floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)