### PR TITLE
chore: simplify mise min_version to hard-only

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,16 +15,6 @@
     "enabled": true,
     "minimumReleaseAge": null
   },
-  "customManagers": [
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^\\.mise\\.toml$/"],
-      "matchStrings": ["soft\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
-      "depNameTemplate": "jdx/mise",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^v?(?<version>.+)$"
-    }
-  ],
   "packageRules": [
     {
       "description": "Disable automerge for major updates",

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,4 +1,4 @@
-min_version = { hard = "2026.4.8", soft = "2026.4.9" }
+min_version = "2026.4.8"
 
 [tools]
 actionlint = "1.7.12"


### PR DESCRIPTION
## Summary
- Revert \`.mise.toml\` \`min_version\` back to the simple string form (hard default).
- Remove the custom regex manager for \`.mise.toml\` from \`renovate.json\`.
- CI keeps following mise releases via \`MISE_VERSION\` in the workflow (already tracked by \`customManagers:githubActionsVersions\`), so no coverage is lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)