### PR TITLE
chore: shorten minimumReleaseAge to 1 day

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,7 +9,7 @@
     ":prConcurrentLimitNone",
     ":prHourlyLimitNone"
   ],
-  "minimumReleaseAge": "3 days",
+  "minimumReleaseAge": "1 day",
   "minimumReleaseAgeBehaviour": "timestamp-optional",
   "vulnerabilityAlerts": {
     "enabled": true,


### PR DESCRIPTION
## Summary

- Change Renovate \`minimumReleaseAge\` from \`3 days\` to \`1 day\`
- Lets pending updates flow through faster

Slightly weakens supply-chain attack protection, but acceptable for a personal project.
🤖 Generated with [Claude Code](https://claude.com/claude-code)