### PR TITLE
chore: add minimum release age to uv and mise

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,8 @@
 min_version = "2026.4.8"
 
+[settings]
+install_before = "1d"
+
 [tools]
 actionlint = "1.7.12"
 "aqua:suzuki-shunsuke/ghalint" = "1.5.5"
@@ -7,7 +10,7 @@ hadolint = "2.14.0"
 node = "24.14.1"
 "aqua:suzuki-shunsuke/pinact" = "3.9.0"
 python = "3.14.4"
-"npm:renovate" = "43.122.0"
+"npm:renovate" = "43.118.0"
 ruff = "0.15.10"
 "aqua:astral-sh/ty" = "0.0.30"
 uv = "0.11.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ dev = [
     "pytest-cov==7.1.0",
 ]
 
+[tool.uv]
+exclude-newer = "1 day"
+
 [tool.ruff]
 include = ["*.py", "app/**/*.py", "tests/**/*.py"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.14"
 
+[options]
+exclude-newer = "2026-04-14T15:33:53.965561253Z"
+exclude-newer-span = "P1D"
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"


### PR DESCRIPTION
## Summary

Defense in depth alongside Renovate's `minimumReleaseAge: 1 day`.

- `pyproject.toml`: `[tool.uv] exclude-newer = "1 day"` (uv 0.9.17+ supports relative durations — a.k.a. dependency cooldowns)
- `.mise.toml`: `[settings] install_before = "1d"`
- Downgrade `npm:renovate` pin from 43.122.0 to 43.118.0 so mise install passes the 1-day cutoff
- `uv.lock` picks up the new `exclude-newer` option automatically

Dockerfile runs `uv sync --frozen`, so no resolution happens at build time; the age check takes effect when the lockfile is updated locally or by Renovate.