### PR TITLE
chore: enable semantic commits for Renovate PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,8 @@
     ":label(dependencies)",
     ":maintainLockFilesDisabled",
     ":prConcurrentLimitNone",
-    ":prHourlyLimitNone"
+    ":prHourlyLimitNone",
+    ":semanticCommits"
   ],
   "minimumReleaseAge": "1 day",
   "minimumReleaseAgeBehaviour": "timestamp-optional",


### PR DESCRIPTION
## Summary

- Add `:semanticCommits` to Renovate extends so PR titles follow Conventional Commits (e.g. `chore(deps): ...`).