### PR TITLE
chore: prevent config:best-practices from overriding minimumReleaseAge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,10 +5,13 @@
     "customManagers:githubActionsVersions",
     ":automergeAll",
     ":label(dependencies)",
-    ":maintainLockFilesDisabled",
     ":prConcurrentLimitNone",
     ":prHourlyLimitNone",
     ":semanticCommits"
+  ],
+  "ignorePresets": [
+    "security:minimumReleaseAgeNpm",
+    ":maintainLockFilesWeekly"
   ],
   "minimumReleaseAge": "1 day",
   "minimumReleaseAgeBehaviour": "timestamp-optional",


### PR DESCRIPTION
## Summary

- `config:best-practices` includes `security:minimumReleaseAgeNpm` which overrides `minimumReleaseAge` to `3 days` for npm packages, preventing the top-level `1 day` setting from taking effect. This caused PRs not to be created for frequently released packages.
- Exclude the preset via `ignorePresets`, and replace `:maintainLockFilesDisabled` with ignoring `:maintainLockFilesWeekly`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)