### PR TITLE
chore: read tool versions from .mise.toml instead of hardcoding in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,14 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    env:
-      # renovate: datasource=github-releases depName=jdx/mise extractVersion=^v?(?<version>.+)$
-      MISE_VERSION: 2026.4.11
-
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Get mise version from .mise.toml
+        run: echo "MISE_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('.mise.toml','rb'))['min_version'])")" >> "$GITHUB_ENV"
 
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -25,14 +25,14 @@ jobs:
     environment: production
     permissions:
       contents: read
-    env:
-      # renovate: datasource=github-releases depName=astral-sh/uv extractVersion=^v?(?<version>.+)$
-      UV_VERSION: 0.11.6
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Get uv version from .mise.toml
+        run: echo "UV_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('.mise.toml','rb'))['tools']['aqua:astral-sh/uv'])")" >> "$GITHUB_ENV"
 
       - name: Generate GitHub App token
         id: app-token


### PR DESCRIPTION
## Summary

- Read `MISE_VERSION` from `min_version` in `.mise.toml` instead of hardcoding in ci.yml
- Read `UV_VERSION` from `tools` in `.mise.toml` instead of hardcoding in renovate.yml
- Eliminate duplicate version management by making `.mise.toml` the single source of truth

🤖 Generated with [Claude Code](https://claude.com/claude-code)