### PR TITLE
fix(deps): override aiohttp to >=3.13.5 to address known vulnerabilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
 
 [tool.uv]
 exclude-newer = "1 day"
+override-dependencies = ["aiohttp>=3.13.5"]
 
 [tool.ruff]
 include = ["*.py", "app/**/*.py", "tests/**/*.py"]

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,9 @@ requires-python = ">=3.14"
 exclude-newer = "2026-04-14T21:42:19.721394148Z"
 exclude-newer-span = "P1D"
 
+[manifest]
+overrides = [{ name = "aiohttp", specifier = ">=3.13.5" }]
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"


### PR DESCRIPTION
## Summary
- litellm pins `aiohttp==3.13.3`, which has multiple known vulnerabilities (see #93)
- Added `override-dependencies = ["aiohttp>=3.13.5"]` in `[tool.uv]` to force a safe version
- This override can be removed once litellm updates its aiohttp dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)