### PR TITLE
chore: remove minimum release age for astral-sh packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,6 +24,12 @@
       "description": "Disable automerge for major updates",
       "matchUpdateTypes": ["major"],
       "automerge": false
+    },
+    {
+      "description": "No minimum release age for astral-sh packages",
+      "matchManagers": ["mise"],
+      "matchPackageNames": ["astral-sh/*"],
+      "minimumReleaseAge": null
     }
   ]
 }

--- a/.mise.toml
+++ b/.mise.toml
@@ -6,12 +6,21 @@ install_before = "1d"
 [tools]
 node = "24.15.0"
 python = "3.14.4"
-"aqua:astral-sh/ruff" = "0.15.10"
-"aqua:astral-sh/ty" = "0.0.30"
-"aqua:astral-sh/uv" = "0.11.6"
 "aqua:hadolint/hadolint" = "2.14.0"
 "aqua:rhysd/actionlint" = "1.7.12"
 "aqua:suzuki-shunsuke/ghalint" = "1.5.5"
 "aqua:suzuki-shunsuke/pinact" = "3.9.0"
 "aqua:zizmorcore/zizmor" = "1.24.1"
 "npm:renovate" = "43.122.0"
+
+[tools."aqua:astral-sh/ruff"]
+version = "0.15.10"
+install_before = "0d"
+
+[tools."aqua:astral-sh/ty"]
+version = "0.0.30"
+install_before = "0d"
+
+[tools."aqua:astral-sh/uv"]
+version = "0.11.6"
+install_before = "0d"


### PR DESCRIPTION
## Summary

- Remove the minimum release age (1-day grace period) for astral-sh packages (ruff, ty, uv) in both mise and Renovate configurations
- astral-sh has comprehensive release security practices (trusted publishing, Sigstore attestation, deployment environment approvals), making the grace period unnecessary
- ref: https://astral.sh/blog/open-source-security-at-astral

🤖 Generated with [Claude Code](https://claude.com/claude-code)