### PR TITLE
chore: enable strict mode for renovate-config-validator

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -29,7 +29,7 @@ actionlint
 ghalint run
 
 # Renovate
-renovate-config-validator
+renovate-config-validator --strict
 
 # Check for uncommitted changes
 git diff --exit-code


### PR DESCRIPTION
## Summary

- Add `--strict` flag to `renovate-config-validator` in `validate.sh`
- Ensures warnings and migration suggestions also cause validation to fail, not just errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)