### PR TITLE
chore: use shared Renovate preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,35 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:best-practices",
-    "customManagers:githubActionsVersions",
-    ":automergeAll",
-    ":label(dependencies)",
-    ":prConcurrentLimitNone",
-    ":prHourlyLimitNone",
-    ":semanticCommits"
-  ],
-  "ignorePresets": [
-    "security:minimumReleaseAgeNpm",
-    ":maintainLockFilesWeekly"
-  ],
-  "minimumReleaseAge": "1 day",
-  "minimumReleaseAgeBehaviour": "timestamp-optional",
-  "vulnerabilityAlerts": {
-    "enabled": true,
-    "minimumReleaseAge": null
-  },
-  "packageRules": [
-    {
-      "description": "Disable automerge for major updates",
-      "matchUpdateTypes": ["major"],
-      "automerge": false
-    },
-    {
-      "description": "No minimum release age for astral-sh packages",
-      "matchManagers": ["mise"],
-      "matchPackageNames": ["astral-sh/*"],
-      "minimumReleaseAge": null
-    }
-  ]
+  "extends": ["github>iwamot/renovate-config#v0.9.0"]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Get mise version from .mise.toml
-        run: echo "MISE_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('.mise.toml','rb'))['min_version'])")" >> "$GITHUB_ENV"
+      - name: Get mise version from mise.toml
+        run: echo "MISE_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('mise.toml','rb'))['min_version'])")" >> "$GITHUB_ENV"
 
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -31,8 +31,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Get uv version from .mise.toml
-        run: echo "UV_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('.mise.toml','rb'))['tools']['aqua:astral-sh/uv'])")" >> "$GITHUB_ENV"
+      - name: Get uv version from mise.toml
+        run: echo "UV_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('mise.toml','rb'))['tools']['aqua:astral-sh/uv'])")" >> "$GITHUB_ENV"
 
       - name: Generate GitHub App token
         id: app-token

--- a/mise.toml
+++ b/mise.toml
@@ -4,14 +4,12 @@ min_version = "2026.4.8"
 install_before = "1d"
 
 [tools]
-node = "24.15.0"
 python = "3.14.4"
 "aqua:hadolint/hadolint" = "2.14.0"
 "aqua:rhysd/actionlint" = "1.7.12"
 "aqua:suzuki-shunsuke/ghalint" = "1.5.5"
 "aqua:suzuki-shunsuke/pinact" = "3.9.0"
 "aqua:zizmorcore/zizmor" = "1.24.1"
-"npm:renovate" = "43.123.6"
 
 [tools."aqua:astral-sh/ruff"]
 version = "0.15.11"

--- a/validate.sh
+++ b/validate.sh
@@ -28,8 +28,5 @@ zizmor --fix .github/workflows/
 actionlint
 ghalint run
 
-# Renovate
-renovate-config-validator --strict
-
 # Check for uncommitted changes
 git diff --exit-code


### PR DESCRIPTION
## Summary
- Replace inline Renovate config with `github>iwamot/renovate-config#v0.9.0`
- Drop `renovate-config-validator` from `validate.sh` (now validated upstream in `iwamot/renovate-config`)
- Remove `npm:renovate` and `node` from `mise.toml` (no longer needed locally)
- Rename `.mise.toml` to `mise.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)