### PR TITLE
chore: use shared mise tasks

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>iwamot/renovate-config#v0.9.0"]
+  "extends": ["github>iwamot/renovate-config#v0.10.0"]
 }

--- a/mise.toml
+++ b/mise.toml
@@ -5,11 +5,6 @@ install_before = "1d"
 
 [tools]
 python = "3.14.4"
-"aqua:hadolint/hadolint" = "2.14.0"
-"aqua:rhysd/actionlint" = "1.7.12"
-"aqua:suzuki-shunsuke/ghalint" = "1.5.5"
-"aqua:suzuki-shunsuke/pinact" = "3.9.0"
-"aqua:zizmorcore/zizmor" = "1.24.1"
 
 [tools."aqua:astral-sh/ruff"]
 version = "0.15.11"
@@ -22,3 +17,8 @@ install_before = "0d"
 [tools."aqua:astral-sh/uv"]
 version = "0.11.7"
 install_before = "0d"
+
+[task_config]
+includes = [
+  "git::https://github.com/iwamot/mise-tasks.git//.mise/tasks?ref=v0.10.0",
+]

--- a/validate.sh
+++ b/validate.sh
@@ -19,14 +19,9 @@ else
   uv run pytest --cov --cov-report=term
 fi
 
-# Dockerfile
-hadolint Dockerfile
-
-# GitHub Actions
-pinact run
-zizmor --fix .github/workflows/
-actionlint
-ghalint run
+# Shared lint tasks
+mise run gha-lint
+mise run docker-lint
 
 # Check for uncommitted changes
 git diff --exit-code


### PR DESCRIPTION
## Summary
- Drop aqua lint tools (`actionlint`/`ghalint`/`pinact`/`zizmor`/`hadolint`) from `mise.toml`
- Reference `iwamot/mise-tasks` v0.10.0 via `[task_config] includes`
- Replace direct lint invocations in `validate.sh` with `mise run gha-lint` and `mise run docker-lint`
- Bump the shared `renovate-config` preset from v0.9.0 to v0.10.0 (enables `minimumReleaseAge: null` for `iwamot/*` and the regex custom manager for `git::` includes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)