### PR TITLE
chore: use shared ci-with-coverage and bump workflows to v0.8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,33 +8,8 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
-  build:
-    name: Run Linting, Type Check, and Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Get mise version from mise.toml
-        run: echo "MISE_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('mise.toml','rb'))['min_version'])")" >> "$GITHUB_ENV"
-
-      - name: Setup mise
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-        with:
-          version: ${{ env.MISE_VERSION }}
-
-      - name: Run validation script
-        run: bash validate.sh
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          use_oidc: true
+  ci:
+    uses: iwamot/workflows/.github/workflows/ci-with-coverage.yml@ddd824917bcf31b58113e4f8b14421436146bc17 # v0.8.0

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -6,5 +6,5 @@ permissions:
   pull-requests: write
 
 jobs:
-  dependabot:
-    uses: iwamot/workflows/.github/workflows/dependabot-auto-merge.yml@3926091bedbf975210db444221da3bc5e3620492 # v0.7.1
+  dependabot-auto-merge:
+    uses: iwamot/workflows/.github/workflows/dependabot-auto-merge.yml@ddd824917bcf31b58113e4f8b14421436146bc17 # v0.8.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   dependency-review:
-    uses: iwamot/workflows/.github/workflows/dependency-review.yml@3926091bedbf975210db444221da3bc5e3620492 # v0.7.1
+    uses: iwamot/workflows/.github/workflows/dependency-review.yml@ddd824917bcf31b58113e4f8b14421436146bc17 # v0.8.0

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   renovate:
-    uses: iwamot/workflows/.github/workflows/renovate.yml@3926091bedbf975210db444221da3bc5e3620492 # v0.7.1
+    uses: iwamot/workflows/.github/workflows/renovate.yml@ddd824917bcf31b58113e4f8b14421436146bc17 # v0.8.0
     with:
       log-level: ${{ inputs.log-level || 'info' }}
     secrets:


### PR DESCRIPTION
## Summary

- Migrate `ci.yml` to call `iwamot/workflows/.github/workflows/ci-with-coverage.yml@v0.8.0` (validate + Codecov via OIDC)
- Add `id-token: write` to the workflow-level permissions so the called job can mint an OIDC token
- Bump the other three reusable workflow references from v0.7.1 to v0.8.0
- Rename caller job ids to match the renamed reusable jobs in v0.8.0:
  - `ci.yml`: `build` → `ci`
  - `dependabot-auto-merge.yml`: `dependabot` → `dependabot-auto-merge`

## Follow-up

After merging, update branch protection required-status-check entries:
- `build / Run Linting, Type Check, and Tests` → `ci / ci-with-coverage`
- `dependabot / dependabot` → `dependabot-auto-merge / dependabot-auto-merge`