### PR TITLE
fix(deps): override python-dotenv to >=1.2.2 for CVE-2026-28684

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
 
 [tool.uv]
 exclude-newer = "1 day"
-override-dependencies = ["aiohttp>=3.13.5"]
+override-dependencies = ["aiohttp>=3.13.5", "python-dotenv>=1.2.2"]
 
 [tool.ruff]
 include = ["*.py", "app/**/*.py", "tests/**/*.py"]

--- a/uv.lock
+++ b/uv.lock
@@ -3,11 +3,14 @@ revision = 3
 requires-python = ">=3.14"
 
 [options]
-exclude-newer = "2026-04-19T03:01:37.351962072Z"
+exclude-newer = "2026-04-21T02:03:55.432988307Z"
 exclude-newer-span = "P1D"
 
 [manifest]
-overrides = [{ name = "aiohttp", specifier = ">=3.13.5" }]
+overrides = [
+    { name = "aiohttp", specifier = ">=3.13.5" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
+]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -1258,11 +1261,11 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.0.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca", size = 39115, upload-time = "2024-01-23T06:33:00.505Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a", size = 19863, upload-time = "2024-01-23T06:32:58.246Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `litellm` pins `python-dotenv==1.0.1`, which is affected by [GHSA-mf9w-mj56-hr94](https://nvd.nist.gov/vuln/detail/CVE-2026-28684) (symlink following in `set_key` allows arbitrary file overwrite via cross-device rename fallback).
- Force-override via `uv`'s `override-dependencies` to pull `python-dotenv>=1.2.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)