### PR TITLE
chore: pass --fix to uv-override-prune

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -10,7 +10,7 @@ mise install
 uv sync --extra dev
 uv run pip-licenses --partial-match --allow-only="Apache;BSD;CNRI-Python;ISC;MIT;MPL;PSF;Python Software Foundation"
 uv audit
-uv run uv-override-prune
+uv run uv-override-prune --fix
 ruff check --fix
 ruff format
 ty check


### PR DESCRIPTION
## Summary

- Match the existing `ruff check --fix` pattern: prunable override entries are auto-fixed locally and surfaced via `git diff` in CI rather than just reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)