### PR TITLE
refactor: use shared shell-lint task

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -24,5 +24,5 @@ install_before = "0d"
 
 [task_config]
 includes = [
-  "git::https://github.com/iwamot/mise-tasks.git//.mise/tasks?ref=v1.4.0",
+  "git::https://github.com/iwamot/mise-tasks.git//.mise/tasks?ref=v1.6.0",
 ]

--- a/validate.sh
+++ b/validate.sh
@@ -22,6 +22,7 @@ fi
 
 # Shared lint tasks
 mise run gha-lint
+mise run shell-lint
 mise run docker-lint
 
 # Check for uncommitted changes


### PR DESCRIPTION
## Summary

- Bump `task_config.includes` to `iwamot/mise-tasks@v1.6.0`. v1.6.0 of the shared `shell-lint` task narrows its scope to git-tracked files, so vendored shell scripts (e.g. `tqdm/completion.sh` inside `.venv/`) no longer trigger spurious shellcheck failures.
- Add `mise run shell-lint` to `validate.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)