### PR TITLE
docs: drop advisory URL line from SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,5 +7,3 @@ This software is provided "as is" without warranty. Security issues will be addr
 ## Reporting a Vulnerability
 
 Please report security vulnerabilities through GitHub's Security Advisory "Report a Vulnerability" feature.
-
-https://github.com/iwamot/collmbo/security/advisories/new


### PR DESCRIPTION
## Summary
- Align SECURITY.md with the iwamot/repo-template baseline by removing the trailing advisory URL.
- The Security Advisory reporting flow remains reachable from the repository's Security tab, so this is purely a cosmetic / consistency change.