### PR TITLE
chore: add oide

### DIFF
--- a/.github/workflows/oide.yml
+++ b/.github/workflows/oide.yml
@@ -1,0 +1,17 @@
+name: oide
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/oide.yml
+
+permissions: {}
+
+jobs:
+  pull:
+    permissions:
+      contents: write       # to push the branch
+      pull-requests: write  # to open the PR
+    uses: iwamot/workflows/.github/workflows/oide.yml@69e4e95359ec485551da77d06323ecc3d9c956a9 # v2.0.0

--- a/Oidefile
+++ b/Oidefile
@@ -1,0 +1,4 @@
+Oidefile
+SECURITY.md
+.github/dco.yml
+.github/release.yml


### PR DESCRIPTION
## Summary

- Add `Oidefile` listing the governance files received from [iwamot/repo-template](https://github.com/iwamot/repo-template).
- Add `.github/workflows/oide.yml` that calls [iwamot/workflows](https://github.com/iwamot/workflows) reusable oide workflow at v2.0.0.

The workflow runs on `workflow_dispatch` and on push when the workflow file changes (e.g., after Renovate-merged ref bumps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
