### PR TITLE
chore: migrate Oide caller to workflows v4.0.0

### DIFF
--- a/.github/workflows/oide.yml
+++ b/.github/workflows/oide.yml
@@ -13,7 +13,10 @@ jobs:
   pull:
     permissions:
       contents: read
-    uses: iwamot/workflows/.github/workflows/oide.yml@afdf21101495a5ec5df69338e8f94ed6ee8cf32d # v3.4.0
+    uses: iwamot/workflows/.github/workflows/oide.yml@1b26eebc34691108a09f9270c9539e03bcabdd4e # v4.0.1
+    with:
+      # renovate: datasource=github-tags depName=iwamot/repo-template
+      TEMPLATE_VERSION: v1.4.0
     secrets:
       RENOVATE_APP_ID: ${{ secrets.RENOVATE_APP_ID }}
       RENOVATE_PRIVATE_KEY: ${{ secrets.RENOVATE_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Migrates the Oide caller to [`iwamot/workflows@v4.0.0`](https://github.com/iwamot/workflows/releases/tag/v4.0.0), which requires `template_version` to be passed explicitly. Initializing at `v1.4.0` of [`iwamot/repo-template`](https://github.com/iwamot/repo-template/releases/tag/v1.4.0).

## Changes

- Bump `uses:` SHA pin to `iwamot/workflows@v4.0.0`
- Add `with: template_version: v1.4.0` (Renovate-managed via `# renovate: datasource=...` annotation)

## Effect

This consumer can now control its own `repo-template` version independently of `iwamot/workflows`. To freeze on a specific version, remove the Renovate annotation. To auto-track, leave it in place.

A side effect: when this PR merges, the push to `oide.yml` triggers the Oide reusable, which pulls the latest `repo-template` files (release.yml with Breaking Changes category, etc.). An Oide PR will follow.