### PR TITLE
chore: prune unused .gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,20 +1,4 @@
-build/
-dist/
-.eggs/
-*.egg-info/
-*.egg
 *.py[cod]
 __pycache__/
 .venv*
-.env*
-# JetBrains PyCharm settings
-.idea/
-.DS_Store
-node_modules/
-.serverless/
-.requirements.zip
-package.json
-package-lock.json
-unzip_requirements.py
 .coverage
-coverage.xml


### PR DESCRIPTION
## Summary

Drop `.gitignore` entries that don't match anything in the working tree.

**Removed**
- Python build artifacts: `build/`, `dist/`, `.eggs/`, `*.egg-info/`, `*.egg`
- IDE/OS: `.idea/`, `.DS_Store`
- Env defense: `.env*`
- Legacy serverless: `.serverless/`, `.requirements.zip`, `unzip_requirements.py`, `package.json`, `package-lock.json`, `node_modules/`
- Misc: `coverage.xml`

The orphan `# JetBrains PyCharm settings` comment (originally sitting above `.idea/`) is dropped in the same pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)