### PR TITLE
chore: remove unused ty: ignore directives

### DIFF
--- a/app/mcp/no_auth_tools_service.py
+++ b/app/mcp/no_auth_tools_service.py
@@ -30,7 +30,7 @@ def load_no_auth_mcp_tools() -> None:
         url = server["url"]
         try:
             client = MCPClient(partial(streamablehttp_client, url))
-            with client:  # ty: ignore[invalid-context-manager]
+            with client:
                 tools = client.list_tools_sync()
             result.extend(
                 transform_mcp_spec_to_classic_tool(
@@ -97,7 +97,7 @@ def process_no_auth_mcp_tool_call(
         str: The response from the tool call.
     """
     mcp_client = MCPClient(lambda: streamablehttp_client(server_url))
-    with mcp_client:  # ty: ignore[invalid-context-manager]
+    with mcp_client:
         result = mcp_client.call_tool_sync(
             tool_use_id=tool_call_id,
             name=tool_name,

--- a/app/mcp/oauth_tools_service.py
+++ b/app/mcp/oauth_tools_service.py
@@ -207,7 +207,7 @@ async def fetch_mcp_oauth_tools(
     headers = create_bearer_auth_headers(token, additional_headers)
 
     client = MCPClient(lambda: streamablehttp_client(server_url, headers=headers))
-    with client:  # ty: ignore[invalid-context-manager]
+    with client:
         mcp_tools = client.list_tools_sync()
 
     for mcp_tool in mcp_tools:
@@ -255,7 +255,7 @@ def process_oauth_mcp_tool_call(
     )
 
     try:
-        with mcp_client:  # ty: ignore[invalid-context-manager]
+        with mcp_client:
             result = mcp_client.call_tool_sync(
                 tool_use_id=tool_call_id,
                 name=tool_name,


### PR DESCRIPTION
## Summary

- Remove four `# ty: ignore[invalid-context-manager]` comments from `app/mcp/no_auth_tools_service.py` and `app/mcp/oauth_tools_service.py` that ty now flags as `unused-ignore-comment` (the underlying invalid-context-manager diagnostic no longer fires, presumably because of upstream typing improvements in the MCP/Strands stack).
- Aligns with the global "no lint/type-check suppressions" policy: when a suppression becomes unused, drop it rather than leave it as silent noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)