### PR TITLE
chore: fail validate.sh on ty warnings

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -13,7 +13,7 @@ uv audit
 uv-override-prune --fix
 ruff check --fix
 ruff format
-ty check
+ty check --error-on-warning
 if [[ -n "$CI" ]]; then
   uv run pytest --cov --cov-report=term --cov-report=xml
 else


### PR DESCRIPTION
## Summary

- Pass `--error-on-warning` to `ty check` in `validate.sh` so warning-level diagnostics (e.g., `unused-ignore-comment`) cause a non-zero exit instead of being silently printed.
- Without this flag, ty's warnings are easy to miss in CI output and accumulate as drift; with it, the next stale `# ty: ignore[...]` or similar will surface as a real CI failure.
- Depends on #230 (which clears the four currently-warning ignore directives) being merged first; this PR is a no-op against current `main` after that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)