### PR TITLE
docs: replace CI/coverage badges with single ghcr badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Collmbo
 
-[![Validate](https://github.com/iwamot/collmbo/actions/workflows/validate.yml/badge.svg)](https://github.com/iwamot/collmbo/actions/workflows/validate.yml)
-[![codecov](https://codecov.io/gh/iwamot/collmbo/branch/main/graph/badge.svg)](https://app.codecov.io/gh/iwamot/collmbo)
+[![ghcr.io](https://img.shields.io/github/v/release/iwamot/collmbo?logo=docker&label=ghcr.io)](https://github.com/iwamot/collmbo/pkgs/container/collmbo)
 
 ![Collmbo icon](https://github.com/user-attachments/assets/b13da1c7-5d2f-4ad3-8c5b-9ef4e500deb8)
 


### PR DESCRIPTION
## Summary

- Drop the Validate (CI status) and codecov badges from the README header.
- Add a single ghcr.io badge that shows the latest released image tag, uses the Docker logo, and links to the GitHub Container Registry package page.

## Why

CI status and coverage are internal quality signals — green is the baseline expectation, and neither helps a prospective user decide whether to try Collmbo. The ghcr badge surfaces what users actually want to know: where the image is distributed (ghcr.io, with the Docker icon), and the latest version. The Release workflow tags the GitHub Release and the ghcr image in lockstep, so `github/v/release` accurately reflects the latest published image.