### PR TITLE
chore: introduce harden-runner in audit mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,16 @@ jobs:
     permissions:
       contents: write  # to create the draft GitHub Release
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
       - uses: iwamot/actions/release-draft@35af46540ea16f3adb318c1a1739572b61f6fc53 # v0.8.0
 
   publish:
     needs: release-draft
-    uses: iwamot/workflows/.github/workflows/publish-ghcr.yml@ae5512be479f765d6f3f89302516a6f5c0add845 # v4.1.3
+    uses: iwamot/workflows/.github/workflows/publish-ghcr.yml@15e638a17daad208034700f2429ee13db2452ce4 # v4.2.0
     permissions:
       contents: read
       id-token: write   # to mint OIDC token for image signing
@@ -40,4 +45,9 @@ jobs:
     permissions:
       contents: write  # to flip the draft GitHub Release to published
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
       - uses: iwamot/actions/release-publish@35af46540ea16f3adb318c1a1739572b61f6fc53 # v0.8.0


### PR DESCRIPTION
## Summary

- Add `step-security/harden-runner` as the first step of every job with steps in `release.yml` (`release-draft`, `release-publish`), running in `egress-policy: audit`.
- Bump `iwamot/workflows/publish-ghcr.yml` from v4.1.2 to v4.2.0 so the `publish` and `merge-and-sign` jobs on the workflows side also run `harden-runner`.
- Audit mode logs outbound network traffic without blocking, so behavior is unchanged. The collected runtime data informs a future move to `block` mode.