### PR TITLE
chore: rename Renovate App secret refs to *_APP_CLIENT_ID

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -25,7 +25,7 @@ jobs:
     with:
       log-level: ${{ inputs.log-level || 'info' }}
     secrets:
-      RENOVATE_APP_ID: ${{ secrets.RENOVATE_APP_ID }}
-      RENOVATE_PRIVATE_KEY: ${{ secrets.RENOVATE_PRIVATE_KEY }}
+      RENOVATE_APP_CLIENT_ID: ${{ secrets.RENOVATE_APP_CLIENT_ID }}
+      RENOVATE_APP_PRIVATE_KEY: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Match the renamed secret inputs in iwamot/workflows v5 by renaming the caller-side secret pass-through to `RENOVATE_APP_CLIENT_ID` / `RENOVATE_APP_PRIVATE_KEY`.