### PR TITLE
chore: migrate release.yml to release-ghcr.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,47 +7,13 @@ on:
 
 permissions: {}
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
-
 jobs:
-  release-draft:
-    name: release-draft
-    runs-on: ubuntu-latest
-    timeout-minutes: 1
+  release:
+    uses: iwamot/workflows/.github/workflows/release-ghcr.yml@d21b0a8606441bf9ace76ad014a80a9165de3a36 # v6.2.0
     permissions:
-      contents: write  # to create the draft GitHub Release
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
-        with:
-          egress-policy: audit
-
-      - uses: iwamot/actions/release-draft@09a90ef28919b6331a2930f6e61eeca11bc634de # v0.9.0
-
-  publish:
-    needs: release-draft
-    uses: iwamot/workflows/.github/workflows/publish-ghcr.yml@d21b0a8606441bf9ace76ad014a80a9165de3a36 # v6.2.0
-    permissions:
-      contents: read
-      id-token: write   # to mint OIDC token for image signing
-      packages: write   # to push to GHCR
+      contents: write  # to draft and publish the GitHub Release
+      packages: write  # to push images to GHCR
+      id-token: write  # to mint OIDC token for cosign signing
     secrets:
       dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
       dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
-
-  release-publish:
-    needs: publish
-    name: release-publish
-    runs-on: ubuntu-latest
-    timeout-minutes: 1
-    permissions:
-      contents: write  # to flip the draft GitHub Release to published
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
-        with:
-          egress-policy: audit
-
-      - uses: iwamot/actions/release-publish@09a90ef28919b6331a2930f6e61eeca11bc634de # v0.9.0


### PR DESCRIPTION
## Summary

Replace the hand-rolled draft → publish-ghcr → publish-flip three-job release pipeline with a single `uses:` call to `iwamot/workflows/.github/workflows/release-ghcr.yml@v6.2.0`, which now carries the draft/publish GitHub Release bookends and the `concurrency` block internally.

No change to the produced release artifacts.