### PR TITLE
chore: remove DCO app config and Oide entry

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,2 +1,0 @@
-allowRemediationCommits:
-  individual: true

--- a/Oidefile
+++ b/Oidefile
@@ -1,4 +1,3 @@
-.github/dco.yml
 .github/release.yml
 CONTRIBUTING.md
 Oidefile


### PR DESCRIPTION
## Summary

- The DCO GitHub App has been uninstalled. The DCO check now runs via the reusable workflow at `iwamot/workflows/.github/workflows/dco.yml`.
- Remove `.github/dco.yml` (the app's config) and the corresponding entry from `Oidefile`.