### PR TITLE
chore: bump iwamot/workflows to v8.0.0 and grant attestation permissions

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -10,4 +10,4 @@ jobs:
   label:
     permissions:
       pull-requests: write  # to add a label to the PR
-    uses: iwamot/workflows/.github/workflows/auto-label.yml@7e1e1b73633f829ea0ac1ca934aa4d085561d61a # v7.1.0
+    uses: iwamot/workflows/.github/workflows/auto-label.yml@1d30033350f397a683dfdf04708d1a510969e9ed # v8.0.0

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -9,4 +9,4 @@ jobs:
   dco:
     permissions:
       pull-requests: read  # to read PR commits for DCO sign-off check
-    uses: iwamot/workflows/.github/workflows/dco.yml@7e1e1b73633f829ea0ac1ca934aa4d085561d61a # v7.1.0
+    uses: iwamot/workflows/.github/workflows/dco.yml@1d30033350f397a683dfdf04708d1a510969e9ed # v8.0.0

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,4 +8,4 @@ jobs:
     permissions:
       contents: write       # to merge auto-merge PRs
       pull-requests: write  # to enable auto-merge
-    uses: iwamot/workflows/.github/workflows/dependabot-auto-merge.yml@7e1e1b73633f829ea0ac1ca934aa4d085561d61a # v7.1.0
+    uses: iwamot/workflows/.github/workflows/dependabot-auto-merge.yml@1d30033350f397a683dfdf04708d1a510969e9ed # v8.0.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,4 +10,4 @@ jobs:
     permissions:
       contents: read
       pull-requests: write  # to comment review summary
-    uses: iwamot/workflows/.github/workflows/dependency-review.yml@7e1e1b73633f829ea0ac1ca934aa4d085561d61a # v7.1.0
+    uses: iwamot/workflows/.github/workflows/dependency-review.yml@1d30033350f397a683dfdf04708d1a510969e9ed # v8.0.0

--- a/.github/workflows/oide.yml
+++ b/.github/workflows/oide.yml
@@ -13,7 +13,7 @@ jobs:
   pull:
     permissions:
       contents: read
-    uses: iwamot/workflows/.github/workflows/oide.yml@7e1e1b73633f829ea0ac1ca934aa4d085561d61a # v7.1.0
+    uses: iwamot/workflows/.github/workflows/oide.yml@1d30033350f397a683dfdf04708d1a510969e9ed # v8.0.0
     with:
       # renovate: datasource=github-tags depName=iwamot/repo-template
       TEMPLATE_VERSION: v1.5.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,13 @@ permissions: {}
 
 jobs:
   release:
-    uses: iwamot/workflows/.github/workflows/release-ghcr.yml@7e1e1b73633f829ea0ac1ca934aa4d085561d61a # v7.1.0
+    uses: iwamot/workflows/.github/workflows/release-ghcr.yml@1d30033350f397a683dfdf04708d1a510969e9ed # v8.0.0
     permissions:
       contents: write  # to draft and publish the GitHub Release
       packages: write  # to push images to GHCR
-      id-token: write  # to mint OIDC token for cosign signing
+      id-token: write  # to mint OIDC tokens for cosign and attest
+      attestations: write  # to write the provenance attestation
+      artifact-metadata: write  # to record artifact metadata for the attestation
     secrets:
       dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
       dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -21,7 +21,7 @@ jobs:
   renovate:
     permissions:
       contents: read
-    uses: iwamot/workflows/.github/workflows/renovate.yml@7e1e1b73633f829ea0ac1ca934aa4d085561d61a # v7.1.0
+    uses: iwamot/workflows/.github/workflows/renovate.yml@1d30033350f397a683dfdf04708d1a510969e9ed # v8.0.0
     with:
       log-level: ${{ inputs.log-level || 'info' }}
     secrets:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,4 +14,4 @@ jobs:
     permissions:
       contents: read
       id-token: write  # for Codecov OIDC upload
-    uses: iwamot/workflows/.github/workflows/validate-with-coverage.yml@7e1e1b73633f829ea0ac1ca934aa4d085561d61a # v7.1.0
+    uses: iwamot/workflows/.github/workflows/validate-with-coverage.yml@1d30033350f397a683dfdf04708d1a510969e9ed # v8.0.0


### PR DESCRIPTION
## Summary
- Bump `iwamot/workflows` references from v7.1.0 to v8.0.0 across all caller workflows
- For `release-ghcr.yml`: grant `attestations: write` and `artifact-metadata: write` on the release job for the new `actions/attest@v4` step inside `merge-and-sign`, and refresh the `id-token: write` comment to note its dual use (cosign + attest)
- The other 7 reusable workflow references (dependabot-auto-merge, renovate, dco, oide, dependency-review, auto-label, validate) are unchanged in v8.0.0; their SHA pins are bumped in lockstep to keep the repo on a single iwamot/workflows version

After the next tag is cut, image consumers can verify SLSA build provenance with:

```
gh attestation verify oci://ghcr.io/iwamot/collmbo:<tag> --owner iwamot
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)