### PR TITLE
chore: remove stale .github/dco.yml and bump TEMPLATE_VERSION to v1.6.0

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,2 +1,0 @@
-allowRemediationCommits:
-  individual: true

--- a/.github/workflows/oide.yml
+++ b/.github/workflows/oide.yml
@@ -16,7 +16,7 @@ jobs:
     uses: iwamot/workflows/.github/workflows/oide.yml@1d30033350f397a683dfdf04708d1a510969e9ed # v8.0.0
     with:
       # renovate: datasource=github-tags depName=iwamot/repo-template
-      TEMPLATE_VERSION: v1.5.0
+      TEMPLATE_VERSION: v1.6.0
     secrets:
       OIDE_APP_CLIENT_ID: ${{ secrets.OIDE_APP_CLIENT_ID }}
       OIDE_APP_PRIVATE_KEY: ${{ secrets.OIDE_APP_PRIVATE_KEY }}

--- a/Oidefile
+++ b/Oidefile
@@ -1,4 +1,3 @@
-.github/dco.yml
 .github/release.yml
 CONTRIBUTING.md
 Oidefile


### PR DESCRIPTION
## Summary
- Remove the stale `.github/dco.yml` (DCO App config) and its `Oidefile` entry
- Bump `oide.yml` `TEMPLATE_VERSION` from v1.5.0 to v1.6.0

## Why
iwamot/repo-template removed `.github/dco.yml` and its Oidefile entry, but the corresponding tag (v1.6.0) was not cut until today. When the previous `oide.yml` SHA bump (#280) merged, the Oide workflow fired with the still-pinned `TEMPLATE_VERSION: v1.5.0`, which re-applied the now-removed entry and brought the file back along with its Oidefile line.

Removing the file and Oidefile entry restores the intended state; bumping `TEMPLATE_VERSION` to v1.6.0 prevents the regression from recurring on the next Oide run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)