### PR TITLE
chore(deps): drop starlette exclude-newer-package override

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dev = [
 
 [tool.uv]
 exclude-newer = "1 day"
-exclude-newer-package = { starlette = "0 day" }
 override-dependencies = [
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -6,9 +6,6 @@ requires-python = ">=3.14"
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P1D"
 
-[options.exclude-newer-package]
-starlette = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"


### PR DESCRIPTION
## Summary
- Remove the `[tool.uv].exclude-newer-package = { starlette = "0 day" }` override added in #299.
- starlette 1.0.1 is now past the global `exclude-newer = "1 day"` window, so the package-specific override is no longer needed and future starlette releases will respect the standard 1-day delay again.