### PR TITLE
chore: merge PyPI JSON and Simple API lookups to tolerate empty JSON responses

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>iwamot/renovate-config#v0.14.0"]
+  "extends": ["github>iwamot/renovate-config#v0.14.0"],
+  "packageRules": [
+    {
+      "description": "Query both the PyPI JSON and Simple APIs and merge results (pypi datasource uses registryStrategy=merge). PyPI's JSON API intermittently returns an empty 200 response, which Renovate reports as a 'no-result' lookup failure; the Simple index then supplies the versions instead. The JSON API stays first so release timestamps (used by minimumReleaseAge) and sourceUrl are retained whenever it responds normally.",
+      "matchDatasources": ["pypi"],
+      "registryUrls": ["https://pypi.org/pypi", "https://pypi.org/simple/"]
+    }
+  ]
 }


### PR DESCRIPTION
## Problem

Renovate runs intermittently emit a warning like:

```
WARN: Package lookup failures
  "Failed to look up pypi package <X>: no-result"
```

The failing package differs from run to run and includes packages that clearly exist (e.g. `litellm`, `httpx`). PyPI's legacy JSON API (`https://pypi.org/pypi/<pkg>/json`) occasionally returns an empty 200 response, and Renovate reports that as a `no-result` lookup failure. Renovate's built-in JSON-to-Simple fallback only triggers when the JSON request *throws* an error, not when it returns an empty 200, so the warning surfaces and that package is skipped for the run.

## Change

The pypi datasource uses `registryStrategy=merge`, which queries every `registryUrl` and merges the results, skipping any that return empty or error. Listing the Simple index alongside the JSON API means the Simple results fill in whenever the JSON API comes back empty.

The JSON API stays first, so in the normal case release timestamps (used by `minimumReleaseAge`) and `sourceUrl` are still taken from it; only a package whose JSON response was empty that run falls back to Simple (no timestamp that run, which `minimumReleaseAgeBehaviour=timestamp-optional` already tolerates).

## Trade-offs

- Not a 100% fix: the rare case where both endpoints return empty in the same run still produces `no-result`, but the probability drops sharply.
- Roughly doubles PyPI lookup requests per run (JSON + Simple). PyPI does not rate-limit the JSON/Index APIs at the edge, so the cost is negligible.

This is applied to collmbo first as a trial; if the warnings drop in practice, the same rule can be promoted to the shared `iwamot/renovate-config` preset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)