### PR TITLE
chore: revert PyPI registryUrls merge that broke uv lock (#348)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,11 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>iwamot/renovate-config#v0.14.0"],
-  "packageRules": [
-    {
-      "description": "Query both the PyPI JSON and Simple APIs and merge results (pypi datasource uses registryStrategy=merge). PyPI's JSON API intermittently returns an empty 200 response, which Renovate reports as a 'no-result' lookup failure; the Simple index then supplies the versions instead. The JSON API stays first so release timestamps (used by minimumReleaseAge) and sourceUrl are retained whenever it responds normally.",
-      "matchDatasources": ["pypi"],
-      "registryUrls": ["https://pypi.org/pypi", "https://pypi.org/simple/"]
-    }
-  ]
+  "extends": ["github>iwamot/renovate-config#v0.14.0"]
 }


### PR DESCRIPTION
Reverts #348.

#348 added `registryUrls: ["https://pypi.org/pypi", "https://pypi.org/simple/"]` to the pypi datasource to work around intermittent empty PyPI JSON API responses (the "no-result" lookup warnings). It regressed instead and must be rolled back.

## What broke

After #348 merged, the next Renovate run produced a `uv.lock` artifact error and the `renovate/artifacts` check went red (blocking automerge of pep621 update PRs):

```
× No solution found when resolving dependencies:
  Because bedrock-agentcore==1.13.0 has no publish time and your project
  depends on bedrock-agentcore==1.13.0 ... requirements are unsatisfiable.
hint: bedrock-agentcore was found on https://pypi.org/pypi, but not at the
requested version. A compatible version may be available on a subsequent
index (e.g., https://pypi.org/simple/). ... use --index-strategy unsafe-best-match
```

## Why

A `registryUrls` value set in `packageRules` is not used only for datasource version lookups — Renovate also passes it to the `uv lock` artifact update as the package index. With `https://pypi.org/pypi` (the JSON API) as uv's first index, uv cannot read PEP 700 upload times, so `[tool.uv] exclude-newer = "1 day"` treats every package as having no publish time and the resolution becomes unsatisfiable.

The two needs are in direct conflict and cannot be satisfied by one `registryUrls` value:
- The datasource wants the JSON API first, to keep release timestamps for `minimumReleaseAge`.
- `uv lock` needs the Simple API, which is the only one that exposes upload times.

The original "no-result" warnings are cosmetic (the affected package is skipped for that run only). Trading them for a broken lock file is not worth it, so this restores the previous configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)