### PR TITLE
chore: add trace log level to renovate workflow dispatch

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -14,6 +14,7 @@ on:
         options:
           - info
           - debug
+          - trace
 
 permissions: {}
 


### PR DESCRIPTION
Add `trace` to the manually dispatchable log levels in this repo's Renovate workflow_dispatch, alongside the existing `info` and `debug`. The reusable iwamot/workflows Renovate workflow accepts any string for its log-level input, so trace is passed through unchanged; this only surfaces it in this repo's manual-dispatch dropdown to help diagnose intermittent Renovate behavior.