### PR TITLE
chore(deps): restore 1-day soak for Slack/AWS packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,13 +30,6 @@ exclude-newer = "1 day"
 override-dependencies = [
 ]
 
-[tool.uv.exclude-newer-package]
-slack-bolt = "0 day"
-slack-sdk = "0 day"
-bedrock-agentcore = "0 day"
-strands-agents = "0 day"
-strands-agents-tools = "0 day"
-
 [tool.ruff]
 include = ["*.py", "app/**/*.py", "tests/**/*.py"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -6,9 +6,6 @@ requires-python = ">=3.14"
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P1D"
 
-[options.exclude-newer-package]
-strands-agents-tools = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
-
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"


### PR DESCRIPTION
Drop the `[tool.uv.exclude-newer-package]` block added in #350, which set `slack-bolt`, `slack-sdk`, `bedrock-agentcore`, `strands-agents`, and `strands-agents-tools` to `"0 day"`.

The exemption was introduced to let a premature `strands-agents-tools` bump through the soak window rather than for a genuine need to skip it. These packages have no requirement to bypass the default 1-day soak, so all five return to the base `exclude-newer = "1 day"`.

`astral-sh` and `iwamot` packages stay fast via the Renovate-side `minimumReleaseAge` override and are unaffected. The current `strands-agents-tools==0.8.0` pin is kept as-is; `uv.lock` only loses the matching options metadata.