### PR TITLE
chore: inherit the 1-day install soak for astral-sh tools

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -5,18 +5,9 @@ install_before = "1d"
 
 [tools]
 python = "3.14.6"
-
-[tools."aqua:astral-sh/ruff"]
-version = "0.15.16"
-install_before = "0d"
-
-[tools."aqua:astral-sh/ty"]
-version = "0.0.47"
-install_before = "0d"
-
-[tools."aqua:astral-sh/uv"]
-version = "0.11.19"
-install_before = "0d"
+"aqua:astral-sh/ruff" = "0.15.16"
+"aqua:astral-sh/ty" = "0.0.47"
+"aqua:astral-sh/uv" = "0.11.19"
 
 [tools."pipx:uv-override-prune"]
 version = "0.0.10"


### PR DESCRIPTION
Drop the per-tool `install_before = "0d"` overrides for the astral-sh tools so they inherit the global `install_before = "1d"` soak. This matches the shared renovate-config preset, which applies a 1-day minimum release age to astral-sh packages.

The `pipx:uv-override-prune` entry keeps its 0d override, since the preset also exempts iwamot's own packages from the soak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)