### PR TITLE
chore: drop redundant install_before, adopt mise minimum_release_age default

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,4 @@
-min_version = "2026.4.8"
-
-[settings]
-install_before = "1d"
+min_version = "2026.6.3"
 
 [tools]
 python = "3.14.6"
@@ -11,7 +8,7 @@ python = "3.14.6"
 
 [tools."pipx:uv-override-prune"]
 version = "0.0.10"
-install_before = "0d"
+minimum_release_age = "0d"
 
 [task_config]
 includes = [


### PR DESCRIPTION
mise v2026.6.2 defaults minimum_release_age to 24h, so drop the now-redundant install_before (raising min_version to 2026.6.3) and rename the per-tool install_before = "0d" override to minimum_release_age = "0d".