### PR TITLE
chore: ignore .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__/
 .venv*
 .coverage
+.env


### PR DESCRIPTION
Add `.env` to `.gitignore` so local environment files are not accidentally committed.