### PR TITLE
fix: use underscore as the MCP tool name separator

### DIFF
--- a/app/mcp/oauth_tools_logic.py
+++ b/app/mcp/oauth_tools_logic.py
@@ -5,7 +5,6 @@ Logic functions for OAuth session management.
 from app.mcp.tools_logic import (
     AUTH_TYPE_ABBREVIATIONS,
     MCP_TOOL_NAME_SEPARATOR,
-    MCP_TOOL_NAME_SEPARATOR_FOR_GEMINI,
 )
 
 
@@ -56,52 +55,27 @@ def parse_mcp_tool_name(tool_name: str) -> tuple[str, str, int]:
     Parse a classic MCP tool name to extract its components.
 
     Args:
-        tool_name (str): Classic tool name in format:
-        - Gemini: "{auth_abbrev}.{server_index}.{spec_name}"
-        - Others: "{auth_abbrev}-{server_index}-{spec_name}"
+        tool_name (str): Classic tool name in format
+        "{auth_abbrev}_{server_index}_{spec_name}".
 
     Returns:
         tuple[str, str, int]: Original spec name, auth type, and server index.
         Returns ("", "", -1) if tool name format is invalid.
     """
-    # Try dot-separated format first (Gemini)
-    if MCP_TOOL_NAME_SEPARATOR_FOR_GEMINI in tool_name:
-        parts = tool_name.split(MCP_TOOL_NAME_SEPARATOR_FOR_GEMINI)
-        if len(parts) >= 3:
-            # First part is auth abbreviation
-            auth_abbrev = parts[0]
-            abbreviation_to_auth_type = {
-                v: k for k, v in AUTH_TYPE_ABBREVIATIONS.items()
-            }
-            auth_type = abbreviation_to_auth_type.get(auth_abbrev)
-            if auth_type:
-                # Second part is server index
-                try:
-                    server_index = int(parts[1])
-                    # Everything after server index is the original spec name
-                    spec_name = MCP_TOOL_NAME_SEPARATOR_FOR_GEMINI.join(parts[2:])
-                    return spec_name, auth_type, server_index
-                except ValueError:
-                    pass
-
-    # Try hyphen-separated format (GPT and others)
-    if MCP_TOOL_NAME_SEPARATOR in tool_name:
-        parts = tool_name.split(MCP_TOOL_NAME_SEPARATOR)
-        if len(parts) >= 3:
-            # First part is auth abbreviation
-            auth_abbrev = parts[0]
-            abbreviation_to_auth_type = {
-                v: k for k, v in AUTH_TYPE_ABBREVIATIONS.items()
-            }
-            auth_type = abbreviation_to_auth_type.get(auth_abbrev)
-            if auth_type:
-                # Second part is server index
-                try:
-                    server_index = int(parts[1])
-                    # Everything after server index is the original spec name
-                    spec_name = MCP_TOOL_NAME_SEPARATOR.join(parts[2:])
-                    return spec_name, auth_type, server_index
-                except ValueError:
-                    pass
+    parts = tool_name.split(MCP_TOOL_NAME_SEPARATOR)
+    if len(parts) >= 3:
+        # First part is auth abbreviation
+        auth_abbrev = parts[0]
+        abbreviation_to_auth_type = {v: k for k, v in AUTH_TYPE_ABBREVIATIONS.items()}
+        auth_type = abbreviation_to_auth_type.get(auth_abbrev)
+        if auth_type:
+            # Second part is server index
+            try:
+                server_index = int(parts[1])
+                # Everything after server index is the original spec name
+                spec_name = MCP_TOOL_NAME_SEPARATOR.join(parts[2:])
+                return spec_name, auth_type, server_index
+            except ValueError:
+                pass
 
     return "", "", -1

--- a/app/mcp/tools_logic.py
+++ b/app/mcp/tools_logic.py
@@ -6,15 +6,12 @@ from copy import deepcopy
 
 from strands.types.tools import ToolSpec
 
-MCP_TOOL_NAME_SEPARATOR = "-"
-MCP_TOOL_NAME_SEPARATOR_FOR_GEMINI = "."
+MCP_TOOL_NAME_SEPARATOR = "_"
 
 AUTH_TYPE_ABBREVIATIONS = {"none": "n", "user_federation": "u", "bearer": "b"}
 
 
-def build_mcp_tool_name(
-    spec_name: str, auth_type: str, server_index: int, model: str
-) -> str:
+def build_mcp_tool_name(spec_name: str, auth_type: str, server_index: int) -> str:
     """
     Build a name for an MCP tool based on its specification name, auth type, and server index.
 
@@ -22,20 +19,12 @@ def build_mcp_tool_name(
         spec_name (str): The name of the tool specification.
         auth_type (str): The authentication type (none, user_federation, bearer).
         server_index (int): The index of the MCP server.
-        model (str): The model name, used to determine separator format.
 
     Returns:
-        str: The constructed tool name. Format depends on model:
-        - Gemini: "{auth_abbrev}.{server_index}.{spec_name}"
-        - Others: "{auth_abbrev}-{server_index}-{spec_name}"
+        str: The constructed tool name in the format
+        "{auth_abbrev}_{server_index}_{spec_name}".
     """
     auth_abbrev = AUTH_TYPE_ABBREVIATIONS.get(auth_type, auth_type)
-
-    # Use dot separator for Gemini models, hyphen for others
-    if model.startswith("gemini/"):
-        return MCP_TOOL_NAME_SEPARATOR_FOR_GEMINI.join(
-            [auth_abbrev, str(server_index), spec_name]
-        )
     return MCP_TOOL_NAME_SEPARATOR.join([auth_abbrev, str(server_index), spec_name])
 
 
@@ -75,9 +64,7 @@ def transform_mcp_spec_to_classic_tool(
     return {
         "type": "function",
         "function": {
-            "name": build_mcp_tool_name(
-                mcp_spec["name"], auth_type, server_index, model
-            ),
+            "name": build_mcp_tool_name(mcp_spec["name"], auth_type, server_index),
             "description": mcp_spec["description"],
             "parameters": parameters,
         },

--- a/app/tools_logic.py
+++ b/app/tools_logic.py
@@ -7,7 +7,6 @@ from importlib import import_module
 from app.mcp.tools_logic import (
     AUTH_TYPE_ABBREVIATIONS,
     MCP_TOOL_NAME_SEPARATOR,
-    MCP_TOOL_NAME_SEPARATOR_FOR_GEMINI,
 )
 
 ABBREVIATION_TO_AUTH_TYPE = {v: k for k, v in AUTH_TYPE_ABBREVIATIONS.items()}
@@ -23,8 +22,39 @@ def is_mcp_tool_name(name: str) -> bool:
     Returns:
         bool: True if the tool is an MCP tool, False otherwise.
     """
-    # Check for both dot-separated (Gemini) and hyphen-separated (GPT) formats
-    return MCP_TOOL_NAME_SEPARATOR_FOR_GEMINI in name or MCP_TOOL_NAME_SEPARATOR in name
+    # An MCP tool name has the structure "{auth_abbrev}_{server_index}_{spec_name}".
+    parts = name.split(MCP_TOOL_NAME_SEPARATOR)
+    if len(parts) < 3:
+        return False
+    auth_abbrev, server_index = parts[0], parts[1]
+    return auth_abbrev in ABBREVIATION_TO_AUTH_TYPE and server_index.isdigit()
+
+
+def split_classic_tools_by_mcp_collision(
+    tools: list[dict],
+) -> tuple[list[dict], list[dict]]:
+    """
+    Partition classic tools by whether their name collides with the MCP tool
+    naming scheme.
+
+    A classic tool whose name is shaped like an MCP tool name would be
+    misrouted to an MCP server instead of being called as a classic tool.
+
+    Args:
+        tools (list[dict]): Classic tools in OpenAI tool format.
+
+    Returns:
+        tuple[list[dict], list[dict]]: (usable tools, colliding tools).
+    """
+    usable: list[dict] = []
+    colliding: list[dict] = []
+    for tool in tools:
+        name = tool.get("function", {}).get("name", "")
+        if is_mcp_tool_name(name):
+            colliding.append(tool)
+        else:
+            usable.append(tool)
+    return usable, colliding
 
 
 def load_classic_tools(module_name: str | None) -> list[dict]:

--- a/app/tools_service.py
+++ b/app/tools_service.py
@@ -24,7 +24,11 @@ from app.mcp.shared_tools_service import (
     process_shared_mcp_tool_call,
 )
 from app.message_logic import build_tool_message
-from app.tools_logic import is_mcp_tool_name, load_classic_tools
+from app.tools_logic import (
+    is_mcp_tool_name,
+    load_classic_tools,
+    split_classic_tools_by_mcp_collision,
+)
 
 classic_tools: list[dict] | None = None
 
@@ -38,7 +42,16 @@ def get_classic_tools() -> list[dict]:
     """
     global classic_tools
     if classic_tools is None:
-        classic_tools = load_classic_tools(TOOLS_MODULE_NAME)
+        usable, colliding = split_classic_tools_by_mcp_collision(
+            load_classic_tools(TOOLS_MODULE_NAME)
+        )
+        for tool in colliding:
+            logging.warning(
+                "Skipping classic tool %r: its name collides with the MCP tool "
+                "naming scheme and would be misrouted to an MCP server.",
+                tool.get("function", {}).get("name", ""),
+            )
+        classic_tools = usable
     return classic_tools
 
 

--- a/tests/mcp/oauth_logic_test.py
+++ b/tests/mcp/oauth_logic_test.py
@@ -126,46 +126,25 @@ def test_create_bearer_auth_headers(token, additional_headers, expected):
 @pytest.mark.parametrize(
     "tool_name, expected",
     [
-        # Gemini format (dot-separated)
         (
-            "u.0.get_user_info",
+            "u_0_get_user_info",
             ("get_user_info", "user_federation", 0),
         ),
         (
-            "u.1.search_repositories",
+            "u_1_search_repositories",
             ("search_repositories", "user_federation", 1),
         ),
         (
-            "n.2.create_issue",
+            "n_2_create_issue",
             ("create_issue", "none", 2),
         ),
         (
-            "u.5.complex-tool-name",
+            "u_5_complex-tool-name",
             ("complex-tool-name", "user_federation", 5),
         ),
+        # Server index with multiple digits
         (
-            "n.10.tool-with-multiple-hyphens-in-name",
-            ("tool-with-multiple-hyphens-in-name", "none", 10),
-        ),
-        # GPT format (hyphen-separated)
-        (
-            "u-0-get_user_info",
-            ("get_user_info", "user_federation", 0),
-        ),
-        (
-            "u-1-search_repositories",
-            ("search_repositories", "user_federation", 1),
-        ),
-        (
-            "n-2-create_issue",
-            ("create_issue", "none", 2),
-        ),
-        (
-            "u-5-complex-tool-name",
-            ("complex-tool-name", "user_federation", 5),
-        ),
-        (
-            "n-10-tool-with-multiple-hyphens-in-name",
+            "n_10_tool-with-multiple-hyphens-in-name",
             ("tool-with-multiple-hyphens-in-name", "none", 10),
         ),
         # Invalid cases
@@ -174,15 +153,15 @@ def test_create_bearer_auth_headers(token, additional_headers, expected):
             ("", "", -1),
         ),
         (
-            "invalid.tool",
+            "invalid_tool",
             ("", "", -1),
         ),
         (
-            "invalid_auth.0.tool",
+            "x_0_tool",
             ("", "", -1),
         ),
         (
-            "u.invalid_index.tool",
+            "u_invalidindex_tool",
             ("", "", -1),
         ),
         (

--- a/tests/mcp/tools_logic_test.py
+++ b/tests/mcp/tools_logic_test.py
@@ -10,20 +10,18 @@ from app.tools_logic import is_mcp_tool_name
 
 
 @pytest.mark.parametrize(
-    "spec_name, auth_type, server_index, model, expected",
+    "spec_name, auth_type, server_index, expected",
     [
-        ("tool1", "none", 0, "gemini/gemini-pro", "n.0.tool1"),
-        ("tool2", "user_federation", 1, "gemini/gemini-pro", "u.1.tool2"),
-        ("tool4", "bearer", 3, "gemini/gemini-pro", "b.3.tool4"),
-        ("tool3", "unknown", 2, "gemini/gemini-pro", "unknown.2.tool3"),
-        ("tool1", "none", 0, "gpt-4", "n-0-tool1"),
-        ("tool2", "user_federation", 1, "gpt-4", "u-1-tool2"),
-        ("tool4", "bearer", 3, "gpt-4", "b-3-tool4"),
-        ("tool3", "unknown", 2, "gpt-4", "unknown-2-tool3"),
+        ("tool1", "none", 0, "n_0_tool1"),
+        ("tool2", "user_federation", 1, "u_1_tool2"),
+        ("tool4", "bearer", 3, "b_3_tool4"),
+        ("tool3", "unknown", 2, "unknown_2_tool3"),
+        ("tool5", "none", 12, "n_12_tool5"),
+        ("get_weather", "bearer", 0, "b_0_get_weather"),
     ],
 )
-def test_build_mcp_tool_name(spec_name, auth_type, server_index, model, expected):
-    result = build_mcp_tool_name(spec_name, auth_type, server_index, model)
+def test_build_mcp_tool_name(spec_name, auth_type, server_index, expected):
+    result = build_mcp_tool_name(spec_name, auth_type, server_index)
 
     assert result == expected
 
@@ -31,16 +29,14 @@ def test_build_mcp_tool_name(spec_name, auth_type, server_index, model, expected
 @pytest.mark.parametrize(
     "tool_name, expected",
     [
-        # Gemini format (dot-separated)
-        ("n.0.tool1", ("tool1", "none", 0)),
-        ("u.1.tool2", ("tool2", "user_federation", 1)),
-        ("b.3.tool4", ("tool4", "bearer", 3)),
-        ("u.2.my-complex-tool", ("my-complex-tool", "user_federation", 2)),
-        # GPT format (hyphen-separated)
-        ("n-0-tool1", ("tool1", "none", 0)),
-        ("u-1-tool2", ("tool2", "user_federation", 1)),
-        ("b-3-tool4", ("tool4", "bearer", 3)),
-        ("u-2-my-complex-tool", ("my-complex-tool", "user_federation", 2)),
+        ("n_0_tool1", ("tool1", "none", 0)),
+        ("u_1_tool2", ("tool2", "user_federation", 1)),
+        ("b_3_tool4", ("tool4", "bearer", 3)),
+        ("u_2_my-complex-tool", ("my-complex-tool", "user_federation", 2)),
+        # Spec names containing the separator round-trip correctly
+        ("u_2_get_user_info", ("get_user_info", "user_federation", 2)),
+        # Server index with multiple digits
+        ("n_10_tool5", ("tool5", "none", 10)),
     ],
 )
 def test_parse_mcp_tool_name(tool_name, expected):
@@ -53,12 +49,9 @@ def test_parse_mcp_tool_name(tool_name, expected):
     "tool_name",
     [
         "tool1",
-        "tool1.n",
-        "tool1-n",
-        "x.0.tool1",
-        "x-0-tool1",
-        "n.abc.tool1",
-        "n-abc-tool1",
+        "tool1_n",
+        "x_0_tool1",
+        "n_abc_tool1",
     ],
 )
 def test_parse_mcp_tool_name_errors(tool_name):
@@ -69,12 +62,18 @@ def test_parse_mcp_tool_name_errors(tool_name):
 @pytest.mark.parametrize(
     "name, expected",
     [
-        ("n.0.tool1", True),
-        ("u.1.tool2", True),
-        ("n-0-tool1", True),
-        ("u-1-tool2", True),
+        ("n_0_tool1", True),
+        ("u_1_tool2", True),
+        ("b_3_tool4", True),
+        ("n_10_tool5", True),
         ("tool3", False),
         ("", False),
+        # Classic tool names with underscores are not misdetected as MCP
+        ("get_weather", False),
+        # Unrecognized auth abbreviation
+        ("x_0_tool1", False),
+        # Non-numeric server index
+        ("n_abc_tool1", False),
     ],
 )
 def test_is_mcp_tool_name(name, expected):
@@ -103,7 +102,7 @@ def test_is_mcp_tool_name(name, expected):
             {
                 "type": "function",
                 "function": {
-                    "name": "n-0-test_tool",
+                    "name": "n_0_test_tool",
                     "description": "Test tool",
                     "parameters": {
                         "type": "object",
@@ -131,7 +130,7 @@ def test_is_mcp_tool_name(name, expected):
             {
                 "type": "function",
                 "function": {
-                    "name": "n.0.test_tool",
+                    "name": "n_0_test_tool",
                     "description": "Test tool",
                     "parameters": {
                         "type": "object",
@@ -159,7 +158,7 @@ def test_is_mcp_tool_name(name, expected):
             {
                 "type": "function",
                 "function": {
-                    "name": "n.0.test_tool",
+                    "name": "n_0_test_tool",
                     "description": "Test tool",
                     "parameters": {
                         "type": "object",
@@ -182,7 +181,7 @@ def test_is_mcp_tool_name(name, expected):
             {
                 "type": "function",
                 "function": {
-                    "name": "n-0-test_tool",
+                    "name": "n_0_test_tool",
                     "description": "Test tool without type",
                     "parameters": {
                         "type": "object",
@@ -203,7 +202,7 @@ def test_is_mcp_tool_name(name, expected):
             {
                 "type": "function",
                 "function": {
-                    "name": "n-0-test_tool",
+                    "name": "n_0_test_tool",
                     "description": "Test tool without properties",
                     "parameters": {"type": "object", "properties": {}},
                 },

--- a/tests/tools_logic_test.py
+++ b/tests/tools_logic_test.py
@@ -1,6 +1,9 @@
 import pytest
 
-from app.tools_logic import load_classic_tools
+from app.tools_logic import (
+    load_classic_tools,
+    split_classic_tools_by_mcp_collision,
+)
 
 
 @pytest.mark.parametrize(
@@ -39,3 +42,42 @@ def test_load_classic_tools(module_name, expected):
     result = load_classic_tools(module_name)
 
     assert result == expected
+
+
+def _classic_tool(name: str) -> dict:
+    return {"type": "function", "function": {"name": name}}
+
+
+@pytest.mark.parametrize(
+    "tools, expected_usable, expected_colliding",
+    [
+        ([], [], []),
+        (
+            [_classic_tool("get_weather"), _classic_tool("search_repositories")],
+            [_classic_tool("get_weather"), _classic_tool("search_repositories")],
+            [],
+        ),
+        (
+            [_classic_tool("n_0_get_weather"), _classic_tool("u_3_search")],
+            [],
+            [_classic_tool("n_0_get_weather"), _classic_tool("u_3_search")],
+        ),
+        (
+            [_classic_tool("get_weather"), _classic_tool("b_2_run")],
+            [_classic_tool("get_weather")],
+            [_classic_tool("b_2_run")],
+        ),
+        (
+            [{"type": "function", "function": {}}],
+            [{"type": "function", "function": {}}],
+            [],
+        ),
+    ],
+)
+def test_split_classic_tools_by_mcp_collision(
+    tools, expected_usable, expected_colliding
+):
+    usable, colliding = split_classic_tools_by_mcp_collision(tools)
+
+    assert usable == expected_usable
+    assert colliding == expected_colliding


### PR DESCRIPTION
## Problem

Gemini models (e.g. `gemini-2.5-flash`) return `finish_reason=MALFORMED_FUNCTION_CALL` and silently drop the tool call when an MCP tool name contains `.`, which was the Gemini-specific separator. LiteLLM normalizes this to an empty response, so MCP tools simply stop working on Gemini with no visible error.

## Change

MCP tool names are encoded as `{auth_abbrev}{sep}{server_index}{sep}{spec_name}`. The separator was `-` for most models and `.` for Gemini. `_` is accepted by every provider, so this unifies the separator to a single `_` for all models and removes the per-model branch (and the now-unused `model` argument of `build_mcp_tool_name`). The Gemini-specific JSON-schema `format` stripping is unrelated and left as-is.

## Collision handling

`-` and `.` cannot appear in classic (function-calling) tool names, which are Python identifiers, so the old scheme distinguished MCP tools from classic tools for free. `_` is valid in identifiers, so that guarantee no longer holds. To compensate:

- `is_mcp_tool_name` is tightened from a substring check to a structural check (known auth abbreviation + numeric server index), so classic tool names containing `_` are not misclassified as MCP tools.
- Classic tools whose name still matches the MCP naming scheme are skipped with a warning at load time, so they can never be silently misrouted to an MCP server. The developer sees the warning and can rename the tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)