### PR TITLE
docs: document SLACK_LOADING_CHARACTER and sort optional settings

### DIFF
--- a/docs/configuration/optional-settings.md
+++ b/docs/configuration/optional-settings.md
@@ -6,9 +6,10 @@ Collmbo works fine with defaults, but you can customize its behavior by setting 
 - `LLM_MAX_TOKENS`
 - `LLM_TEMPERATURE`
 - `LLM_TIMEOUT_SECONDS`
-- `SYSTEM_PROMPT_TEMPLATE` (Use `{bot_user_id}` placeholder for the bot's Slack user ID.)
 - `SLACK_APP_LOG_LEVEL`
+- `SLACK_LOADING_CHARACTER`
 - `SLACK_UPDATE_TEXT_BUFFER_SIZE` (Slack message update buffer size. Increase if hitting rate limits.)
+- `SYSTEM_PROMPT_TEMPLATE` (Use `{bot_user_id}` placeholder for the bot's Slack user ID.)
 - `USE_SLACK_LOCALE` (If `"false"`, ignores Slack locale and lets the model handle translations.)
 
 See [`app/env.py`](../../app/env.py) for details.


### PR DESCRIPTION
`SLACK_LOADING_CHARACTER` is supported in `app/env.py` but was missing from the optional settings reference. This adds it to the list.

While here, the list is sorted in ascending name order; `SYSTEM_PROMPT_TEMPLATE` was previously out of place.

Docs only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)