### PR TITLE
feat: bump default LLM_MODEL to gpt-5.5

### DIFF
--- a/app/env.py
+++ b/app/env.py
@@ -83,7 +83,7 @@ Only mention users (e.g., `<@U12345>`) when you are explicitly instructed to do 
 SYSTEM_PROMPT_TEMPLATE = get_env(
     "SYSTEM_PROMPT_TEMPLATE", DEFAULT_SYSTEM_PROMPT_TEMPLATE
 )
-LLM_MODEL = get_env("LLM_MODEL", "gpt-5.2")
+LLM_MODEL = get_env("LLM_MODEL", "gpt-5.5")
 LLM_TIMEOUT_SECONDS = get_env("LLM_TIMEOUT_SECONDS", 30)
 LLM_TEMPERATURE = get_env("LLM_TEMPERATURE", 1.0)
 LLM_MAX_TOKENS = get_env("LLM_MAX_TOKENS", 2048)


### PR DESCRIPTION
The default `LLM_MODEL` (used when the env var is unset) was still `gpt-5.2`, while the README and feature docs already point to `gpt-5.5`. This bumps the default so the out-of-the-box model matches the documented one.

This changes runtime behavior for users who do not set `LLM_MODEL`: they now get `gpt-5.5` instead of `gpt-5.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)