### PR TITLE
feat: add vector store (knowledge base) retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Collmbo does not serve endpoints and can run in any environment with internet ac
 
 - **[MCP Tools](docs/features/mcp-tools.md)** - Extends functionality with MCP server.
 - **[Tools (Function Calling)](docs/features/tools-function-calling.md)** - Extends functionality with function calling.
+- **[Vector Store](docs/features/vector-store.md)** - Retrieves context from a knowledge base (RAG).
 - **[Custom Callbacks](docs/features/custom-callbacks.md)** - Hooks into requests and responses for custom processing.
 - **[Redaction](docs/features/redaction.md)** - Masks sensitive information before sending requests.
 - **[Slack-friendly Formatting](docs/features/slack-friendly-formatting.md)** - Formats messages for better readability in Slack.

--- a/app/env.py
+++ b/app/env.py
@@ -106,6 +106,10 @@ PDF_INPUT_ENABLED = get_env("PDF_INPUT_ENABLED", "false") == "true"
 # Tools
 TOOLS_MODULE_NAME = get_env("TOOLS_MODULE_NAME")
 
+# Vector store
+VECTOR_STORE_IDS = get_env("VECTOR_STORE_IDS")
+VECTOR_STORE_PROVIDER = get_env("VECTOR_STORE_PROVIDER")
+
 # Prompt caching
 PROMPT_CACHING_ENABLED = get_env("PROMPT_CACHING_ENABLED", "false") == "true"
 PROMPT_CACHING_TTL = get_env("PROMPT_CACHING_TTL")

--- a/app/tools_logic.py
+++ b/app/tools_logic.py
@@ -57,6 +57,34 @@ def split_classic_tools_by_mcp_collision(
     return usable, colliding
 
 
+def split_classic_tools_by_reserved_name(
+    tools: list[dict],
+    reserved_name: str,
+) -> tuple[list[dict], list[dict]]:
+    """
+    Partition classic tools by whether their name matches a reserved tool name.
+
+    A classic tool that reuses a reserved name would be misrouted to the built-in
+    tool that owns that name instead of being called as a classic tool.
+
+    Args:
+        tools (list[dict]): Classic tools in OpenAI tool format.
+        reserved_name (str): The reserved tool name.
+
+    Returns:
+        tuple[list[dict], list[dict]]: (usable tools, colliding tools).
+    """
+    usable: list[dict] = []
+    colliding: list[dict] = []
+    for tool in tools:
+        name = tool.get("function", {}).get("name", "")
+        if name == reserved_name:
+            colliding.append(tool)
+        else:
+            usable.append(tool)
+    return usable, colliding
+
+
 def load_classic_tools(module_name: str | None) -> list[dict]:
     """
     Load tools from a module.

--- a/app/tools_service.py
+++ b/app/tools_service.py
@@ -28,7 +28,10 @@ from app.tools_logic import (
     is_mcp_tool_name,
     load_classic_tools,
     split_classic_tools_by_mcp_collision,
+    split_classic_tools_by_reserved_name,
 )
+from app.vector_store_logic import VECTOR_STORE_TOOL_NAME
+from app.vector_store_service import get_vector_store_tools, run_vector_store_search
 
 classic_tools: list[dict] | None = None
 
@@ -51,6 +54,15 @@ def get_classic_tools() -> list[dict]:
                 "naming scheme and would be misrouted to an MCP server.",
                 tool.get("function", {}).get("name", ""),
             )
+        usable, reserved = split_classic_tools_by_reserved_name(
+            usable, VECTOR_STORE_TOOL_NAME
+        )
+        for tool in reserved:
+            logging.warning(
+                "Skipping classic tool %r: its name is reserved for the vector "
+                "store search tool.",
+                tool.get("function", {}).get("name", ""),
+            )
         classic_tools = usable
     return classic_tools
 
@@ -70,7 +82,7 @@ def get_all_tools(
     Returns:
         list[dict]: A list of all tools.
     """
-    tools = get_classic_tools() + get_shared_mcp_tools()
+    tools = get_classic_tools() + get_shared_mcp_tools() + get_vector_store_tools()
 
     # Add authenticated MCP tools only for DM conversations
     # DM channels start with 'D' (direct message)
@@ -144,6 +156,17 @@ def process_tool_call(
     tool_name = tool_call.function.name
     if not tool_name:
         logging.warning("Skipped tool call with empty name: %s", tool_call)
+        return
+
+    if tool_name == VECTOR_STORE_TOOL_NAME:
+        arguments = json.loads(tool_call.function.arguments)
+        tool_response = run_vector_store_search(arguments.get("query", ""))
+        tool_message = build_tool_message(
+            tool_call_id=tool_call.id,
+            name=tool_name,
+            content=tool_response,
+        )
+        messages.append(tool_message)
         return
 
     if not is_mcp_tool_name(tool_name) and TOOLS_MODULE_NAME is not None:

--- a/app/vector_store_logic.py
+++ b/app/vector_store_logic.py
@@ -1,0 +1,82 @@
+"""
+This module contains logical functions for vector store retrieval.
+"""
+
+from litellm.types.vector_stores import VectorStoreSearchResponse
+
+VECTOR_STORE_TOOL_NAME = "collmbo_search_knowledge_base"
+NO_RESULTS_MESSAGE = "No relevant information was found in the knowledge base."
+
+
+def parse_vector_store_ids(raw: str) -> list[str]:
+    """
+    Parse a comma-separated list of vector store IDs.
+
+    Args:
+        raw (str): The raw comma-separated value.
+
+    Returns:
+        list[str]: The parsed IDs with surrounding whitespace stripped and empties dropped.
+    """
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def build_vector_store_tool() -> dict:
+    """
+    Build the function tool definition the model calls to search the knowledge base.
+
+    Returns:
+        dict: The tool definition in OpenAI function-calling format.
+    """
+    return {
+        "type": "function",
+        "function": {
+            "name": VECTOR_STORE_TOOL_NAME,
+            "description": (
+                "Search the knowledge base for information relevant to the user's "
+                "question. Call this whenever the answer may depend on the user's own "
+                "documents, then answer using the results."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "The search query.",
+                    },
+                },
+                "required": ["query"],
+            },
+        },
+    }
+
+
+def build_tool_result_content(
+    search_responses: list[VectorStoreSearchResponse],
+) -> str:
+    """
+    Combine vector store search responses into the content of a tool message.
+
+    Args:
+        search_responses (list[VectorStoreSearchResponse]): The responses, one per store.
+
+    Returns:
+        str: The concatenated result texts, or a fallback message when there are none.
+    """
+    texts: list[str] = []
+    for search_response in search_responses:
+        data = search_response.get("data")
+        if not data:
+            continue
+        for result in data:
+            result_content = result.get("content")
+            if not result_content:
+                continue
+            for content_item in result_content:
+                text = content_item.get("text")
+                if text:
+                    texts.append(text)
+
+    if not texts:
+        return NO_RESULTS_MESSAGE
+    return "\n\n".join(texts)

--- a/app/vector_store_service.py
+++ b/app/vector_store_service.py
@@ -1,0 +1,72 @@
+"""
+This module provides service functions for vector store retrieval.
+
+The model decides when to search via a function tool. On a tool call, Collmbo runs the
+search through ``litellm.vector_stores.search()`` and returns the results as the tool
+output, so no separate LiteLLM proxy is required.
+"""
+
+import logging
+import os
+
+import litellm
+import litellm.vector_stores
+
+from app.env import VECTOR_STORE_IDS, VECTOR_STORE_PROVIDER
+from app.vector_store_logic import (
+    build_tool_result_content,
+    build_vector_store_tool,
+    parse_vector_store_ids,
+)
+
+
+def get_vector_store_tools() -> list[dict]:
+    """
+    Return the knowledge base search tool when the feature is configured.
+
+    Returns:
+        list[dict]: A single-element list with the tool, or an empty list when the
+        feature is unconfigured. A missing provider logs a warning and disables it.
+    """
+    if not VECTOR_STORE_IDS or not parse_vector_store_ids(VECTOR_STORE_IDS):
+        return []
+
+    if not VECTOR_STORE_PROVIDER:
+        logging.warning(
+            "VECTOR_STORE_IDS is set but VECTOR_STORE_PROVIDER is not; "
+            "the knowledge base search tool is disabled."
+        )
+        return []
+
+    return [build_vector_store_tool()]
+
+
+def run_vector_store_search(query: str) -> str:
+    """
+    Search the configured vector stores and return the results as tool content.
+
+    A failing search logs a warning and is skipped rather than failing the tool call.
+
+    Args:
+        query (str): The search query provided by the model.
+
+    Returns:
+        str: The combined search results as the content of a tool message.
+    """
+    search_responses = []
+    for vector_store_id in parse_vector_store_ids(VECTOR_STORE_IDS or ""):
+        try:
+            search_response = litellm.vector_stores.search(
+                vector_store_id=vector_store_id,
+                query=query,
+                custom_llm_provider=VECTOR_STORE_PROVIDER,
+                aws_region_name=os.environ.get("AWS_REGION_NAME"),
+            )
+        except Exception:
+            logging.warning(
+                "Vector store search failed for %s; skipping.", vector_store_id
+            )
+            continue
+        search_responses.append(search_response)
+
+    return build_tool_result_content(search_responses)

--- a/docs/features/vector-store.md
+++ b/docs/features/vector-store.md
@@ -1,0 +1,27 @@
+# Vector Store
+
+Collmbo can retrieve context from a vector store (knowledge base) so the model can answer from your own documents (RAG).
+
+The model is given a search tool and decides when to use it. The search runs through [LiteLLM's vector store integration](https://docs.litellm.ai/docs/completion/knowledgebase), so any provider it supports works.
+
+## Usage
+
+Set `VECTOR_STORE_IDS` to your vector store ID and `VECTOR_STORE_PROVIDER` to its provider:
+
+```sh
+$ cat env
+SLACK_APP_TOKEN=xapp-1-...
+SLACK_BOT_TOKEN=xoxb-...
+OPENAI_API_KEY=sk-...
+LLM_MODEL=gpt-5.5
+VECTOR_STORE_IDS=vs_...
+VECTOR_STORE_PROVIDER=openai
+
+$ docker run -it --env-file ./env ghcr.io/iwamot/collmbo:latest
+```
+
+To search multiple stores, separate IDs with commas:
+
+```sh
+VECTOR_STORE_IDS=vs_aaa,vs_bbb
+```

--- a/tests/tools_logic_test.py
+++ b/tests/tools_logic_test.py
@@ -3,6 +3,7 @@ import pytest
 from app.tools_logic import (
     load_classic_tools,
     split_classic_tools_by_mcp_collision,
+    split_classic_tools_by_reserved_name,
 )
 
 
@@ -78,6 +79,39 @@ def test_split_classic_tools_by_mcp_collision(
     tools, expected_usable, expected_colliding
 ):
     usable, colliding = split_classic_tools_by_mcp_collision(tools)
+
+    assert usable == expected_usable
+    assert colliding == expected_colliding
+
+
+@pytest.mark.parametrize(
+    "tools, reserved_name, expected_usable, expected_colliding",
+    [
+        ([], "reserved", [], []),
+        (
+            [_classic_tool("get_weather"), _classic_tool("search")],
+            "reserved",
+            [_classic_tool("get_weather"), _classic_tool("search")],
+            [],
+        ),
+        (
+            [_classic_tool("get_weather"), _classic_tool("reserved")],
+            "reserved",
+            [_classic_tool("get_weather")],
+            [_classic_tool("reserved")],
+        ),
+        (
+            [{"type": "function", "function": {}}],
+            "reserved",
+            [{"type": "function", "function": {}}],
+            [],
+        ),
+    ],
+)
+def test_split_classic_tools_by_reserved_name(
+    tools, reserved_name, expected_usable, expected_colliding
+):
+    usable, colliding = split_classic_tools_by_reserved_name(tools, reserved_name)
 
     assert usable == expected_usable
     assert colliding == expected_colliding

--- a/tests/vector_store_logic_test.py
+++ b/tests/vector_store_logic_test.py
@@ -1,0 +1,64 @@
+import pytest
+
+from app.vector_store_logic import (
+    NO_RESULTS_MESSAGE,
+    VECTOR_STORE_TOOL_NAME,
+    build_tool_result_content,
+    build_vector_store_tool,
+    parse_vector_store_ids,
+)
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("kb-1", ["kb-1"]),
+        ("kb-1,kb-2", ["kb-1", "kb-2"]),
+        (" kb-1 , kb-2 ", ["kb-1", "kb-2"]),
+        ("kb-1,,kb-2,", ["kb-1", "kb-2"]),
+        ("", []),
+        ("  ,  ", []),
+    ],
+)
+def test_parse_vector_store_ids(raw, expected):
+    result = parse_vector_store_ids(raw)
+
+    assert result == expected
+
+
+def test_build_vector_store_tool():
+    result = build_vector_store_tool()
+
+    assert result["type"] == "function"
+    assert result["function"]["name"] == VECTOR_STORE_TOOL_NAME
+    assert result["function"]["parameters"]["required"] == ["query"]
+    assert "query" in result["function"]["parameters"]["properties"]
+
+
+@pytest.mark.parametrize(
+    "search_responses, expected",
+    [
+        (
+            [{"data": [{"content": [{"text": "chunk one"}]}]}],
+            "chunk one",
+        ),
+        (
+            [
+                {"data": [{"content": [{"text": "a"}, {"text": "b"}]}]},
+                {"data": [{"content": [{"text": "c"}]}]},
+            ],
+            "a\n\nb\n\nc",
+        ),
+        ([], NO_RESULTS_MESSAGE),
+        ([{"data": None}], NO_RESULTS_MESSAGE),
+        ([{"data": []}], NO_RESULTS_MESSAGE),
+        ([{}], NO_RESULTS_MESSAGE),
+        ([{"data": [{"content": None}]}], NO_RESULTS_MESSAGE),
+        ([{"data": [{"content": [{"text": None}]}]}], NO_RESULTS_MESSAGE),
+        ([{"data": [{"content": [{}]}]}], NO_RESULTS_MESSAGE),
+    ],
+)
+def test_build_tool_result_content(search_responses, expected):
+    result = build_tool_result_content(search_responses)
+
+    assert result == expected


### PR DESCRIPTION
Collmbo can now retrieve context from a vector store (knowledge base) so the model can answer from your own documents (RAG). The model is given a search tool and decides when to use it, then answers from the results.

Set `VECTOR_STORE_IDS` (comma-separated for multiple stores) and `VECTOR_STORE_PROVIDER` (e.g. `openai`, `bedrock`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
