### PR TITLE
feat: allow customizing the knowledge base search tool description

### DIFF
--- a/app/env.py
+++ b/app/env.py
@@ -109,6 +109,14 @@ TOOLS_MODULE_NAME = get_env("TOOLS_MODULE_NAME")
 # Vector store
 VECTOR_STORE_IDS = get_env("VECTOR_STORE_IDS")
 VECTOR_STORE_PROVIDER = get_env("VECTOR_STORE_PROVIDER")
+DEFAULT_VECTOR_STORE_TOOL_DESCRIPTION = (
+    "Search the knowledge base for information relevant to the user's "
+    "question. Call this whenever the answer may depend on the user's own "
+    "documents, then answer using the results."
+)
+VECTOR_STORE_TOOL_DESCRIPTION = get_env(
+    "VECTOR_STORE_TOOL_DESCRIPTION", DEFAULT_VECTOR_STORE_TOOL_DESCRIPTION
+)
 
 # Prompt caching
 PROMPT_CACHING_ENABLED = get_env("PROMPT_CACHING_ENABLED", "false") == "true"

--- a/app/vector_store_logic.py
+++ b/app/vector_store_logic.py
@@ -21,9 +21,13 @@ def parse_vector_store_ids(raw: str) -> list[str]:
     return [item.strip() for item in raw.split(",") if item.strip()]
 
 
-def build_vector_store_tool() -> dict:
+def build_vector_store_tool(description: str) -> dict:
     """
     Build the function tool definition the model calls to search the knowledge base.
+
+    Args:
+        description (str): The tool description shown to the model. It guides when the
+            model searches, so it can be tailored to the contents of the knowledge base.
 
     Returns:
         dict: The tool definition in OpenAI function-calling format.
@@ -32,11 +36,7 @@ def build_vector_store_tool() -> dict:
         "type": "function",
         "function": {
             "name": VECTOR_STORE_TOOL_NAME,
-            "description": (
-                "Search the knowledge base for information relevant to the user's "
-                "question. Call this whenever the answer may depend on the user's own "
-                "documents, then answer using the results."
-            ),
+            "description": description,
             "parameters": {
                 "type": "object",
                 "properties": {

--- a/app/vector_store_service.py
+++ b/app/vector_store_service.py
@@ -12,7 +12,11 @@ import os
 import litellm
 import litellm.vector_stores
 
-from app.env import VECTOR_STORE_IDS, VECTOR_STORE_PROVIDER
+from app.env import (
+    VECTOR_STORE_IDS,
+    VECTOR_STORE_PROVIDER,
+    VECTOR_STORE_TOOL_DESCRIPTION,
+)
 from app.vector_store_logic import (
     build_tool_result_content,
     build_vector_store_tool,
@@ -38,7 +42,7 @@ def get_vector_store_tools() -> list[dict]:
         )
         return []
 
-    return [build_vector_store_tool()]
+    return [build_vector_store_tool(VECTOR_STORE_TOOL_DESCRIPTION)]
 
 
 def run_vector_store_search(query: str) -> str:

--- a/docs/features/vector-store.md
+++ b/docs/features/vector-store.md
@@ -25,3 +25,9 @@ To search multiple stores, separate IDs with commas:
 ```sh
 VECTOR_STORE_IDS=vs_aaa,vs_bbb
 ```
+
+The model decides when to search based on the search tool's description. Set `VECTOR_STORE_TOOL_DESCRIPTION` to tailor it to your documents, since only you know what the knowledge base contains:
+
+```sh
+VECTOR_STORE_TOOL_DESCRIPTION=Search the internal HR handbook for company policies, benefits, and leave rules.
+```

--- a/tests/vector_store_logic_test.py
+++ b/tests/vector_store_logic_test.py
@@ -27,10 +27,11 @@ def test_parse_vector_store_ids(raw, expected):
 
 
 def test_build_vector_store_tool():
-    result = build_vector_store_tool()
+    result = build_vector_store_tool("Search the knowledge base.")
 
     assert result["type"] == "function"
     assert result["function"]["name"] == VECTOR_STORE_TOOL_NAME
+    assert result["function"]["description"] == "Search the knowledge base."
     assert result["function"]["parameters"]["required"] == ["query"]
     assert "query" in result["function"]["parameters"]["properties"]
 


### PR DESCRIPTION
Add `VECTOR_STORE_TOOL_DESCRIPTION` so operators can tailor the knowledge base search tool's description to the contents of their store, guiding when the model decides to search. It defaults to the previous wording, so existing deployments are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)