### PR TITLE
fix: skip empty chat.update to avoid no_text error

### DIFF
--- a/app/litellm_service.py
+++ b/app/litellm_service.py
@@ -389,6 +389,10 @@ def update_reply_text(
     text = assistant_reply_text
     if with_loading_character:
         text += SLACK_LOADING_CHARACTER
+    # Slack rejects chat.update with empty text (no_text). Reasoning models can
+    # emit whitespace-only content on a tool-call turn, which formats to "" here.
+    if not text.strip():
+        return
     client.chat_update(channel=channel, ts=wip_message["ts"], text=text)
 
 


### PR DESCRIPTION
When a reasoning model emits whitespace-only `content` on a tool-call turn, it formats to an empty string in `update_reply_text`. Posting that to `chat.update` raises a `no_text` Slack API error, which aborts the reply before the tool calls are processed.

Skip the update when the text is empty