### PR TITLE
fix: stop spamming the loading message during multi-step replies

### DIFF
--- a/app/bolt_listeners.py
+++ b/app/bolt_listeners.py
@@ -140,7 +140,6 @@ def respond_to_new_post(
             user_id=user_id,
             thread_ts=reply_thread_ts,
             messages=messages,
-            loading_text=loading_text,
             wip_reply=wip_reply,
             timeout_seconds=LLM_TIMEOUT_SECONDS,
         )

--- a/app/litellm_logic.py
+++ b/app/litellm_logic.py
@@ -32,3 +32,21 @@ def is_final_chunk(chunk: ModelResponse) -> bool:
         bool: True if the chunk is the final chunk, False otherwise.
     """
     return chunk.choices[0].get("finish_reason") is not None
+
+
+def has_visible_text(content: str) -> bool:
+    """
+    Check whether streamed assistant content has visible text.
+
+    Reasoning models may end a tool-calling turn with empty or whitespace-only
+    content. Such a turn leaves nothing worth preserving in the Slack message, so
+    the in-progress placeholder can be reused for the next round rather than
+    posting a fresh one.
+
+    Args:
+        content (str): The accumulated assistant content for the turn.
+
+    Returns:
+        bool: True if the content has non-whitespace text.
+    """
+    return bool(content and content.strip())

--- a/app/litellm_service.py
+++ b/app/litellm_service.py
@@ -24,7 +24,11 @@ from app.env import (
     SLACK_LOADING_CHARACTER,
     SLACK_UPDATE_TEXT_BUFFER_SIZE,
 )
-from app.litellm_logic import extract_delta_content, is_final_chunk
+from app.litellm_logic import (
+    extract_delta_content,
+    has_visible_text,
+    is_final_chunk,
+)
 from app.message_logic import (
     build_assistant_message,
     convert_markdown_to_mrkdwn,
@@ -46,7 +50,6 @@ def reply_to_slack_with_litellm(
     user_id: str,
     thread_ts: str | None,
     messages: list[dict],
-    loading_text: str,
     wip_reply: dict | SlackResponse,
     timeout_seconds: int,
 ) -> None:
@@ -59,7 +62,6 @@ def reply_to_slack_with_litellm(
         user_id (str): The user ID of the person who initiated the conversation.
         thread_ts (Optional[str]): The timestamp of the thread to reply to.
         messages (list[dict]): The list of messages to include in the reply.
-        loading_text (str): The text to display while waiting for a response.
         wip_reply (Union[dict, SlackResponse]): The message object for the in-progress reply.
         timeout_seconds (int): The timeout duration in seconds.
 
@@ -80,7 +82,6 @@ def reply_to_slack_with_litellm(
         messages=messages,
         stream=stream,
         thread_ts=thread_ts,
-        loading_text=loading_text,
         timeout_seconds=timeout_seconds,
     )
 
@@ -175,7 +176,6 @@ def stream_litellm_reply_to_slack(
     messages: list[dict],
     stream: CustomStreamWrapper,
     thread_ts: str | None,
-    loading_text: str,
     timeout_seconds: int,
 ):
     """
@@ -189,7 +189,6 @@ def stream_litellm_reply_to_slack(
         messages (list[dict]): The list of messages to include in the reply.
         stream (CustomStreamWrapper): The stream wrapper for the response.
         thread_ts (Optional[str]): The timestamp of the thread to reply to.
-        loading_text (str): The text to display while waiting for a response.
         timeout_seconds (int): The timeout duration in seconds.
 
     Returns:
@@ -210,21 +209,21 @@ def stream_litellm_reply_to_slack(
         messages.append(assistant_message)
         if not is_response_too_long:
             break
-        wip_reply = client.chat_postMessage(
-            channel=channel,
-            thread_ts=thread_ts,
-            text=SLACK_LOADING_CHARACTER,
+        wip_reply = post_loading_placeholder(
+            client=client, channel=channel, thread_ts=thread_ts
         )
 
     if response_message is None or response_message.tool_calls is None:
         return
 
-    # If the message has already been updated, post a new one
-    if (wip_message := wip_reply["message"]) and wip_message["text"] != loading_text:
-        wip_reply = client.chat_postMessage(
-            channel=channel,
-            thread_ts=thread_ts,
-            text=loading_text,
+    # If the model streamed visible narration into the current message, keep it
+    # and start a fresh placeholder for the next tool-calling round. If the turn
+    # produced no visible text (e.g. a pure tool call, or whitespace-only content
+    # from a reasoning model), reuse the existing placeholder instead of stacking
+    # another one -- this is what stops multi-step replies from spamming loaders.
+    if has_visible_text(assistant_message["content"]):
+        wip_reply = post_loading_placeholder(
+            client=client, channel=channel, thread_ts=thread_ts
         )
 
     process_tool_calls(
@@ -240,8 +239,34 @@ def stream_litellm_reply_to_slack(
         user_id=user_id,
         messages=messages,
         thread_ts=thread_ts,
-        loading_text=loading_text,
         timeout_seconds=int(timeout_seconds - (time.time() - start_time)),
+    )
+
+
+def post_loading_placeholder(
+    *,
+    client: WebClient,
+    channel: str,
+    thread_ts: str | None,
+) -> SlackResponse:
+    """
+    Posts a lightweight loading placeholder message to a Slack thread.
+
+    Used between tool-calling rounds and when continuing a too-long reply, so the
+    next chunk of the response has a message to stream into.
+
+    Args:
+        client (WebClient): The Slack WebClient instance.
+        channel (str): The Slack channel ID.
+        thread_ts (Optional[str]): The timestamp of the thread to reply to.
+
+    Returns:
+        SlackResponse: The Slack API response for the posted message.
+    """
+    return client.chat_postMessage(
+        channel=channel,
+        thread_ts=thread_ts,
+        text=SLACK_LOADING_CHARACTER,
     )
 
 

--- a/tests/litellm_logic_test.py
+++ b/tests/litellm_logic_test.py
@@ -1,7 +1,11 @@
 import pytest
 from litellm.types.utils import Choices, Delta, Message, ModelResponse, StreamingChoices
 
-from app.litellm_logic import extract_delta_content, is_final_chunk
+from app.litellm_logic import (
+    extract_delta_content,
+    has_visible_text,
+    is_final_chunk,
+)
 
 
 @pytest.mark.parametrize(
@@ -74,5 +78,22 @@ def test_extract_delta_content(chunk, expected):
 )
 def test_is_final_chunk(chunk, expected):
     result = is_final_chunk(chunk)
+
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "content, expected",
+    [
+        # Real narration -> visible text, must be preserved
+        ("Let me check the weather for you.", True),
+        # Pure tool call leaves content empty -> nothing to preserve
+        ("", False),
+        # Reasoning models can emit whitespace-only content on a tool-call turn
+        ("   \n\t ", False),
+    ],
+)
+def test_has_visible_text(content, expected):
+    result = has_visible_text(content)
 
     assert result == expected


### PR DESCRIPTION
## Problem

When a reply involves multiple tool-calling rounds, `stream_litellm_reply_to_slack` posted a fresh `:hourglass_flowing_sand: Wait a second, please ...` (`LOADING_TEXT`) message for **every** round whose previous message had gained real content. Multi-step ("thinking") replies therefore stacked several loading messages in the thread, each one also firing a Slack notification.

The old check decided whether to post a new message by comparing the in-progress message text against `loading_text`:

```python
# If the message has already been updated, post a new one
if (wip_message := wip_reply["message"]) and wip_message["text"] != loading_text:
    wip_reply = client.chat_postMessage(..., text=loading_text)
```

Inferring "is this still a placeholder?" from the message text is fragile:

- A reasoning model that ends a tool-call turn with **whitespace-only content** makes `update_reply_text` set `wip_message["text"] = ""` in memory while skipping the actual `chat.update` (the `no_text` guard), so the text no longer matches `loading_text` and a new loader is posted anyway — the spam persists.
- It depends on Slack round-tripping the exact loading text back in the API response.

## Fix

Decide whether to start a new message from **whether the turn actually streamed visible text**, which is already available in `assistant_message["content"]`:

- If the turn produced visible narration, keep that message and post a fresh placeholder for the next round.
- If it produced no visible text (a pure tool call, or whitespace-only content from a reasoning model), reuse the existing placeholder instead of stacking another one.

The decision uses a small, unit-tested `has_visible_text()` helper in `app/litellm_logic.py` (matching the existing `_logic` test convention) instead of string-matching Slack message text. Inter-round placeholders use the lightweight `SLACK_LOADING_CHARACTER` rather than the verbose loading text.

Also:
- The two identical placeholder-posting sites (too-long continuation and between tool rounds) are unified in a `post_loading_placeholder()` helper.
- The now-unused `loading_text` parameter is dropped from the streaming layer. The one-time initial "Wait a second, please ..." loader is still posted by `post_loading_reply`.

## Result

- One initial "Wait a second, please ..." message (unchanged).
- Subsequent tool-calling rounds either reuse the placeholder (no visible text) or preserve their narration and show a minimal "... :writing_hand:" placeholder that fills with the next round's text.
- No more repeated "Wait a second, please ..." messages during multi-step replies, including for reasoning models that emit whitespace-only tool-call turns.

## Testing

- `uv run pytest` — 320 passed
- `ruff check` / `ruff format --check` — clean
- `ty check` — clean