### PR TITLE
chore: move dev dependencies to a PEP 735 dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,9 @@ dependencies = [
     "strands-agents-tools==0.8.3",
 ]
 
-[project.optional-dependencies]
+# The dev group is included by `uv sync` and `uv run` by default, and
+# excluded from the container by `uv sync --no-dev`.
+[dependency-groups]
 dev = [
     "pip-licenses==5.5.5",
     "pytest==9.1.1",

--- a/uv.lock
+++ b/uv.lock
@@ -307,7 +307,7 @@ dependencies = [
     { name = "strands-agents-tools" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "pip-licenses" },
     { name = "pytest" },
@@ -321,15 +321,18 @@ requires-dist = [
     { name = "litellm", specifier = "==1.91.2" },
     { name = "mcp", specifier = "==1.28.1" },
     { name = "pillow", specifier = "==12.3.0" },
-    { name = "pip-licenses", marker = "extra == 'dev'", specifier = "==5.5.5" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = "==9.1.1" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = "==7.1.0" },
     { name = "slack-bolt", specifier = "==1.29.0" },
     { name = "slack-sdk", specifier = "==3.43.0" },
     { name = "strands-agents", specifier = "==1.47.0" },
     { name = "strands-agents-tools", specifier = "==0.8.3" },
 ]
-provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pip-licenses", specifier = "==5.5.5" },
+    { name = "pytest", specifier = "==9.1.1" },
+    { name = "pytest-cov", specifier = "==7.1.0" },
+]
 
 [[package]]
 name = "colorama"

--- a/validate.sh
+++ b/validate.sh
@@ -7,7 +7,7 @@ mise fmt
 mise install
 
 # Python
-uv sync --extra dev
+uv sync
 uv run pip-licenses --partial-match --allow-only="Apache;BSD;CNRI-Python;ISC;MIT;MPL;PSF;Python Software Foundation"
 uv audit
 uv-override-prune --fix


### PR DESCRIPTION
## Summary

Replaces the `dev` extra (`[project.optional-dependencies]`) with a PEP 735 dependency group (`[dependency-groups]`).

- uv includes the `dev` group in `uv sync` and `uv run` by default, so `validate.sh` drops `--extra dev` in favor of a plain `uv sync`.
- The container build already runs `uv sync --frozen --no-dev`; after this change that `--no-dev` flag is what actually excludes the dev group from the image.
- `uv.lock` is regenerated for the new structure; resolved versions are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)