### PR TITLE
fix(deps): relock litellm 1.93.0 to include the x86_64 wheel

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -759,6 +759,7 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/93/e1/4f05ca4cbb4efb739c9e66a182ecd5c816bc05bf3665ec8e0fb4ab408379/litellm-1.93.0.tar.gz", hash = "sha256:140bf215e264c71601bca9c06d2436c5451bb59e1e195ea23fc2d3d87b6929ec", size = 15948866, upload-time = "2026-07-19T03:01:24.389Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/7f/b48d88cb32055b4ba7e51cd67e4ea13a589d4a568d33c3d0dc6994d13b83/litellm-1.93.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:1a476ebc340c070c982eab15b4673fa63a70f5936935f9f20e4d2acb5f35d23b", size = 20165502, upload-time = "2026-07-19T03:01:18.425Z" },
+    { url = "https://files.pythonhosted.org/packages/45/6c/65a7f916326daa151131f1fce5e254d4834127a95d53a18f1c4d238dd5c3/litellm-1.93.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:cd70ccd4ba3ef1a395535c287bce72d30c7d937ecca4290c0db37a00738f7ada", size = 20159007, upload-time = "2026-07-19T03:01:21.704Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The v11.4.5 release failed on the `publish-ghcr (linux/amd64)` job ([failed run](https://github.com/iwamot/collmbo/actions/runs/29738356036)): `uv sync --frozen --no-dev` tried to build litellm 1.93.0 from the sdist and died with `linker cc not found`, since the slim image ships no compiler. The linux/arm64 job succeeded.

Root cause: Renovate locked litellm 1.93.0 (#511) while PyPI's index only listed the aarch64 wheel, so `uv.lock` recorded no x86_64 wheel. PyPI has since listed the full wheel matrix.

## Fix

`uv lock --refresh-package litellm` — a one-line lock change that adds the `cp314-manylinux_2_28_x86_64` wheel entry, so linux/amd64 installs the wheel instead of building the sdist.

## Verification

- `validate.sh` passes (320 tests)
- The full Docker image build, including the previously failing `uv sync --frozen --no-dev` layer, succeeds locally on amd64

🤖 Generated with [Claude Code](https://claude.com/claude-code)