### PR TITLE
fix: narrow mimetype to str before building image URL item

### DIFF
--- a/app/slack_image_service.py
+++ b/app/slack_image_service.py
@@ -35,7 +35,7 @@ def build_image_url_items_from_slack_files(
 
     for file in files:
         mime_type = file.get("mimetype")
-        if mime_type not in SUPPORTED_IMAGE_MIME_TYPES:
+        if mime_type is None or mime_type not in SUPPORTED_IMAGE_MIME_TYPES:
             continue
         file_url = file.get("url_private")
         if file_url is None:


### PR DESCRIPTION
## Summary

ty 0.0.62 (#542) no longer narrows `Unknown | None` to `str` via a `not in` membership check, so the `validate` job fails on #542 with:

```
error[invalid-argument-type]: Argument to function `build_image_url_item` is incorrect
  --> app/slack_image_service.py:63:47
```

This PR adds an explicit `mime_type is None` guard so the type narrows to `str` before `build_image_url_item(mime_type, image_bytes)` is called.

No runtime behavior change: a `None` mimetype already hit `continue` because `None not in SUPPORTED_IMAGE_MIME_TYPES` was always `True`.

## Verification

- `ty check` passes on this file with both ty 0.0.61 and 0.0.62
- `ruff check` / `ruff format --check` pass

Once merged, Renovate should rebase #542 and its `validate` check should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)