### PR TITLE
chore: resolve lint violations from ruff 0.16 default rule expansion

### DIFF
--- a/app/bolt_listeners.py
+++ b/app/bolt_listeners.py
@@ -61,6 +61,8 @@ from app.slack_image_service import build_image_url_items_from_slack_files
 from app.slack_pdf_service import build_pdf_file_items_from_slack_files
 from app.translation_service import translate
 
+logger = logging.getLogger(__name__)
+
 LOADING_TEXT = ":hourglass_flowing_sand: Wait a second, please ..."
 TIMEOUT_ERROR_MESSAGE = (
     f":warning: Apologies! It seems that the AI didn't respond within the "
@@ -158,6 +160,7 @@ def respond_to_new_post(
             thread_ts=reply_thread_ts,
         )
     except Exception as e:
+        logger.exception("Failed to reply")
         handle_exception(
             client=client,
             channel_id=context.channel_id,
@@ -531,7 +534,6 @@ def handle_exception(
         None
     """
     text = f":warning: Failed to reply: {e}"
-    client.logger.exception(text)
     client.chat_postMessage(
         channel=channel_id,
         thread_ts=thread_ts,
@@ -555,8 +557,8 @@ def handle_app_home_opened(client: WebClient, event: dict) -> None:
     expire_old_oauth_sessions(user_id)
     try:
         update_home_tab(client=client, user_id=user_id)
-    except Exception as e:
-        logging.error(f"Failed to update home tab: {e}")
+    except Exception:
+        logger.exception("Failed to update home tab")
         update_home_tab(
             client=client,
             user_id=user_id,
@@ -583,8 +585,8 @@ def handle_enable_mcp_oauth_action(body: dict, client: WebClient) -> None:
             server_index=server_index,
             on_update=update_home_tab,
         )
-    except Exception as e:
-        logging.error(f"Failed to handle enable auth action: {e}")
+    except Exception:
+        logger.exception("Failed to handle enable auth action")
         update_home_tab(
             client=client,
             user_id=body["user"]["id"],
@@ -614,8 +616,8 @@ def handle_disable_mcp_oauth_action(
             server_index=server_index,
             on_update=update_home_tab,
         )
-    except Exception as e:
-        logging.error(f"Failed to handle disable auth action: {e}")
+    except Exception:
+        logger.exception("Failed to handle disable auth action")
         update_home_tab(
             client=client,
             user_id=body["user"]["id"],
@@ -645,8 +647,8 @@ def handle_cancel_mcp_oauth_action(
             server_index=server_index,
             on_update=update_home_tab,
         )
-    except Exception as e:
-        logging.error(f"Failed to handle cancel auth action: {e}")
+    except Exception:
+        logger.exception("Failed to handle cancel auth action")
         update_home_tab(
             client=client,
             user_id=body["user"]["id"],

--- a/app/bolt_middlewares.py
+++ b/app/bolt_middlewares.py
@@ -10,6 +10,8 @@ from slack_sdk.web import WebClient
 
 from app.bolt_logic import extract_user_id_from_context, should_skip_event
 
+logger = logging.getLogger(__name__)
+
 
 def before_authorize(
     body: dict,
@@ -31,7 +33,7 @@ def before_authorize(
         Optional[BoltResponse]: A BoltResponse object if the event is skipped, None otherwise.
     """
     if should_skip_event(body, payload):
-        logging.debug(
+        logger.debug(
             "Skipped the following middleware and listeners "
             f"for this message event (subtype: {payload.get('subtype')})"
         )

--- a/app/env.py
+++ b/app/env.py
@@ -38,7 +38,7 @@ def get_env(new_name: str, default: None = None) -> str | None: ...
 
 
 def get_env(
-    new_name: str, default: str | int | float | None = None
+    new_name: str, default: str | float | None = None
 ) -> str | int | float | None:
     """
     Get an environment variable with deprecation warning support.

--- a/app/home_tab_service.py
+++ b/app/home_tab_service.py
@@ -17,6 +17,8 @@ from app.mcp.oauth_tools_service import (
     get_user_oauth_sessions,
 )
 
+logger = logging.getLogger(__name__)
+
 
 def get_user_timezone(client: WebClient, user_id: str) -> str:
     """
@@ -36,7 +38,7 @@ def get_user_timezone(client: WebClient, user_id: str) -> str:
             if user_data and hasattr(user_data, "get"):
                 return user_data.get("tz", "UTC")
     except Exception:
-        logging.debug("Failed to get user timezone")
+        logger.debug("Failed to get user timezone", exc_info=True)
     return "UTC"
 
 

--- a/app/litellm_service.py
+++ b/app/litellm_service.py
@@ -38,6 +38,8 @@ from app.tools_service import get_all_tools, process_tool_calls
 
 litellm.drop_params = True
 
+logger = logging.getLogger(__name__)
+
 if LITELLM_CALLBACK_MODULE_NAME is not None:
     callback_module = import_module(LITELLM_CALLBACK_MODULE_NAME)
     litellm.callbacks = [callback_module.CallbackHandler()]
@@ -333,7 +335,7 @@ def handle_litellm_stream(
             try:
                 t.join()
             except Exception:
-                logging.debug("Failed to join thread")
+                logger.debug("Failed to join thread", exc_info=True)
 
     # Final update to remove the loading character after stream ends
     if len(assistant_message["content"]) > 0:

--- a/app/mcp/agentcore_service.py
+++ b/app/mcp/agentcore_service.py
@@ -12,6 +12,8 @@ from bedrock_agentcore.services.identity import IdentityClient, TokenPoller
 
 from app.mcp.agentcore_logic import create_agentcore_user_id
 
+logger = logging.getLogger(__name__)
+
 # OAuth token polling timeout in seconds
 OAUTH_POLLING_TIMEOUT_SECONDS = 300
 OAUTH_POLLING_INTERVAL_SECONDS = 5
@@ -81,7 +83,7 @@ def shutdown_all_oauth_pollers() -> None:
         try:
             poller.cancel()
         except Exception:
-            logging.debug("Failed to cancel OAuth poller")
+            logger.debug("Failed to cancel OAuth poller", exc_info=True)
     active_oauth_pollers.clear()
 
 
@@ -158,7 +160,7 @@ def create_workload_identity_token(
                     allowed_resource_oauth_2_return_urls=callback_urls,
                 )
         else:
-            raise e
+            raise
     token_response = client.get_workload_access_token(
         workload_identity_name,
         user_id=agentcore_user_id,
@@ -263,5 +265,4 @@ async def initiate_oauth_flow_with_callback(
             on_timeout_callback()
     finally:
         # Remove poller from active list
-        if key in active_oauth_pollers:
-            del active_oauth_pollers[key]
+        active_oauth_pollers.pop(key, None)

--- a/app/mcp/oauth_control_service.py
+++ b/app/mcp/oauth_control_service.py
@@ -128,11 +128,11 @@ def create_token_callback(
                 token=token,
             )
             on_update(client, user_id)
-        except Exception as e:
+        except Exception:
             # If tool fetching fails, clear the session to return to disabled state
             clear_user_oauth_session(user_id, server_name)
             # Re-raise the exception to maintain error logging and debugging capability
-            raise e
+            raise
 
     return on_token_callback
 

--- a/app/mcp/shared_tools_service.py
+++ b/app/mcp/shared_tools_service.py
@@ -16,6 +16,8 @@ from app.mcp.config_logic import build_bearer_headers
 from app.mcp.config_service import get_bearer_servers, get_no_auth_servers
 from app.mcp.tools_logic import transform_mcp_spec_to_classic_tool
 
+logger = logging.getLogger(__name__)
+
 REFRESH_INTERVAL_SECONDS = 3600
 
 shared_mcp_tools: list[dict] = []
@@ -69,13 +71,13 @@ def load_shared_mcp_tools() -> None:
                     url=url, headers=None, auth_type="none", server_index=idx
                 )
             )
-        except Exception as exc:
-            logging.warning("Failed to load MCP tools from %s: %s", url, exc)
+        except Exception:
+            logger.warning("Failed to load MCP tools from %s", url, exc_info=True)
     for idx, server in enumerate(get_bearer_servers()):
         url = server["url"]
         headers = build_bearer_headers(server, os.environ)
         if headers is None:
-            logging.warning(
+            logger.warning(
                 "Skipping bearer MCP server %s: token env var %r is not set",
                 server.get("name"),
                 server.get("token_env"),
@@ -87,8 +89,8 @@ def load_shared_mcp_tools() -> None:
                     url=url, headers=headers, auth_type="bearer", server_index=idx
                 )
             )
-        except Exception as exc:
-            logging.warning("Failed to load MCP tools from %s: %s", url, exc)
+        except Exception:
+            logger.warning("Failed to load MCP tools from %s", url, exc_info=True)
     shared_mcp_tools = result
 
 
@@ -114,7 +116,7 @@ def start_shared_mcp_tools_refresh_loop() -> None:
         while True:
             time.sleep(REFRESH_INTERVAL_SECONDS)
             load_shared_mcp_tools()
-            logging.info(f"Shared MCP tools refreshed: {len(shared_mcp_tools)} tools")
+            logger.info(f"Shared MCP tools refreshed: {len(shared_mcp_tools)} tools")
 
     threading.Thread(
         target=refresh_loop,

--- a/app/message_logic.py
+++ b/app/message_logic.py
@@ -381,7 +381,7 @@ def convert_markdown_to_mrkdwn(content: str) -> str:
     # Apply the bold, italic, and strikethrough formatting to text not within code
     result = ""
     for idx, part in enumerate(parts):
-        if part.startswith("```") or part.startswith("`"):
+        if part.startswith(("```", "`")):
             # Insert ASCII spaces around code spans/blocks when adjacent to
             # East Asian wide/fullwidth characters to improve readability.
             left_space = False

--- a/app/slack_image_service.py
+++ b/app/slack_image_service.py
@@ -10,6 +10,8 @@ from PIL import Image
 from app.message_logic import build_image_url_item
 from app.slack_file_service import get_slack_file_content
 
+logger = logging.getLogger(__name__)
+
 SUPPORTED_IMAGE_FORMATS = ["jpeg", "png", "gif", "webp"]
 SUPPORTED_IMAGE_MIME_TYPES = [f"image/{fmt}" for fmt in SUPPORTED_IMAGE_FORMATS]
 
@@ -39,7 +41,7 @@ def build_image_url_items_from_slack_files(
             continue
         file_url = file.get("url_private")
         if file_url is None:
-            logging.warning("Skipped an image file due to missing 'url_private'")
+            logger.warning("Skipped an image file due to missing 'url_private'")
             continue
 
         image_bytes = get_slack_file_content(
@@ -52,10 +54,10 @@ def build_image_url_items_from_slack_files(
         except Exception as e:
             raise RuntimeError(f"Failed to open an image data: {e}") from e
         if image.format is None:
-            logging.warning(f"Skipped image with unknown format (url: {file_url})")
+            logger.warning(f"Skipped image with unknown format (url: {file_url})")
             continue
         if image.format.lower() not in SUPPORTED_IMAGE_FORMATS:
-            logging.info(
+            logger.info(
                 f"Skipped unsupported image (url: {file_url}, format: {image.format})"
             )
             continue

--- a/app/slack_pdf_service.py
+++ b/app/slack_pdf_service.py
@@ -7,6 +7,8 @@ import logging
 from app.message_logic import build_pdf_file_item
 from app.slack_file_service import get_slack_file_content
 
+logger = logging.getLogger(__name__)
+
 
 def build_pdf_file_items_from_slack_files(
     *,
@@ -38,7 +40,7 @@ def build_pdf_file_items_from_slack_files(
             continue
         file_url = file.get("url_private")
         if file_url is None:
-            logging.warning("Skipped a PDF file due to missing 'url_private'")
+            logger.warning("Skipped a PDF file due to missing 'url_private'")
             continue
 
         pdf_bytes = get_slack_file_content(
@@ -47,7 +49,7 @@ def build_pdf_file_items_from_slack_files(
             expected_content_types=["application/pdf", "binary/octet-stream"],
         )
         if not pdf_bytes.startswith(b"%PDF-"):
-            logging.warning(f"Skipped invalid PDF (url: {file_url})")
+            logger.warning(f"Skipped invalid PDF (url: {file_url})")
             continue
 
         file_item = build_pdf_file_item(file.get("name"), pdf_bytes)

--- a/app/tools_service.py
+++ b/app/tools_service.py
@@ -33,6 +33,8 @@ from app.tools_logic import (
 from app.vector_store_logic import VECTOR_STORE_TOOL_NAME
 from app.vector_store_service import get_vector_store_tools, run_vector_store_search
 
+logger = logging.getLogger(__name__)
+
 classic_tools: list[dict] | None = None
 
 
@@ -49,7 +51,7 @@ def get_classic_tools() -> list[dict]:
             load_classic_tools(TOOLS_MODULE_NAME)
         )
         for tool in colliding:
-            logging.warning(
+            logger.warning(
                 "Skipping classic tool %r: its name collides with the MCP tool "
                 "naming scheme and would be misrouted to an MCP server.",
                 tool.get("function", {}).get("name", ""),
@@ -58,7 +60,7 @@ def get_classic_tools() -> list[dict]:
             usable, VECTOR_STORE_TOOL_NAME
         )
         for tool in reserved:
-            logging.warning(
+            logger.warning(
                 "Skipping classic tool %r: its name is reserved for the vector "
                 "store search tool.",
                 tool.get("function", {}).get("name", ""),
@@ -155,7 +157,7 @@ def process_tool_call(
     """
     tool_name = tool_call.function.name
     if not tool_name:
-        logging.warning("Skipped tool call with empty name: %s", tool_call)
+        logger.warning("Skipped tool call with empty name: %s", tool_call)
         return
 
     if tool_name == VECTOR_STORE_TOOL_NAME:

--- a/app/vector_store_service.py
+++ b/app/vector_store_service.py
@@ -23,6 +23,8 @@ from app.vector_store_logic import (
     parse_vector_store_ids,
 )
 
+logger = logging.getLogger(__name__)
+
 
 def get_vector_store_tools() -> list[dict]:
     """
@@ -36,7 +38,7 @@ def get_vector_store_tools() -> list[dict]:
         return []
 
     if not VECTOR_STORE_PROVIDER:
-        logging.warning(
+        logger.warning(
             "VECTOR_STORE_IDS is set but VECTOR_STORE_PROVIDER is not; "
             "the knowledge base search tool is disabled."
         )
@@ -67,8 +69,10 @@ def run_vector_store_search(query: str) -> str:
                 aws_region_name=os.environ.get("AWS_REGION_NAME"),
             )
         except Exception:
-            logging.warning(
-                "Vector store search failed for %s; skipping.", vector_store_id
+            logger.warning(
+                "Vector store search failed for %s; skipping.",
+                vector_store_id,
+                exc_info=True,
             )
             continue
         search_responses.append(search_response)

--- a/main.py
+++ b/main.py
@@ -29,6 +29,8 @@ from app.env import SLACK_APP_LOG_LEVEL, USE_SLACK_LOCALE
 from app.mcp.agentcore_service import shutdown_all_oauth_pollers
 from app.mcp.shared_tools_service import start_shared_mcp_tools_refresh_loop
 
+logger = logging.getLogger(__name__)
+
 
 def main() -> None:
     """
@@ -118,12 +120,12 @@ def register_signal_handlers(slack_handler: SocketModeHandler) -> None:
     """
 
     def handler(signum: int, _: FrameType | None) -> None:
-        logging.info("Received %s, shutting down...", signal.Signals(signum).name)
+        logger.info("Received %s, shutting down...", signal.Signals(signum).name)
         shutdown_all_oauth_pollers()
         try:
             slack_handler.close()
         except Exception:
-            logging.debug("Failed to close slack handler")
+            logger.debug("Failed to close slack handler", exc_info=True)
         sys.exit(0)
 
     for signum in (signal.SIGTERM, signal.SIGINT):

--- a/oauth-callback-app/lambda_handler.py
+++ b/oauth-callback-app/lambda_handler.py
@@ -8,11 +8,14 @@ Deploy this as a Lambda function with Function URL enabled.
 """
 
 import json
+import logging
 import os
 
 import boto3
 
 AGENTCORE_REGION = os.environ.get("AGENTCORE_REGION", "us-west-2")
+
+logger = logging.getLogger(__name__)
 
 
 def lambda_handler(event, context):
@@ -255,8 +258,8 @@ def lambda_handler(event, context):
                 </html>
                 """,
             }
-        except Exception as e:
-            print(f"CompleteResourceTokenAuth failed: {e}")
+        except Exception:
+            logger.exception("CompleteResourceTokenAuth failed")
             return {
                 "statusCode": 400,
                 "headers": {"Content-Type": "text/html; charset=utf-8"},


### PR DESCRIPTION
## Summary

ruff 0.16.0 expands its default rule set from 59 to 413 rules. Since this repo extends the defaults via `extend-select`, the Renovate bump to ruff 0.16.0 (#547) newly reports 42 violations (BLE001, LOG015, TRY201, PIE810, PYI041, RUF051). This PR fixes all of them in code, without adding any ignore comments, so the config keeps following ruff's default rule set.

## Changes

- **LOG015** (root logger calls): each affected module now defines `logger = logging.getLogger(__name__)` and logs through it instead of the root logger.
- **BLE001** (blind `except Exception`): exception handlers now record the exception — `logging.error(f"... {e}")` becomes `logger.exception("...")` (same ERROR level, traceback added), and debug/warning-level handlers keep their level with `exc_info=True` added.
- In `respond_to_new_post`, the log call moved from inside `handle_exception` (`client.logger.exception`) to the catch site (`logger.exception`), since BLE001 requires the logging to happen in the `except` body. The Slack error message posting is unchanged.
- In `oauth-callback-app/lambda_handler.py`, the `print` in the exception handler becomes `logger.exception`, so the Lambda logs the traceback through the runtime's preconfigured logging setup.
- **TRY201**: `raise e` → `raise`.
- **PIE810**: two `startswith` calls merged into one tuple call.
- **PYI041**: `int | float` → `float` in the `get_env` implementation signature; the overloads and runtime `isinstance` checks are unchanged.
- **RUF051**: `if key in dict: del dict[key]` → `dict.pop(key, None)`.

Once merged, #547 should pass after a rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)