### PR TITLE
chore: enable uv's malware check during sync

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,11 @@ exclude-newer = "1 day"
 override-dependencies = [
 ]
 
+[tool.uv.audit]
+# Check the locked packages against OSV malware advisories before any sync
+# installs them, so a compromised release cannot run its install hooks here.
+malware-check = true
+
 [tool.ruff]
 include = ["*.py", "app/**/*.py", "tests/**/*.py"]
 


### PR DESCRIPTION
Locked packages are now checked against OSV malware advisories before a sync installs them, so a compromised release cannot run its install hooks.

This complements `uv audit`, which covers vulnerabilities and adverse project statuses rather than malware advisories. Because it lives in `pyproject.toml` rather than in CI configuration, the check applies to local `uv sync` runs as well — the point of the check is to stop the code before it runs, which is on the developer's machine first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)