### PR TITLE
chore: run auto-label when a pull request title is edited

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,7 +1,7 @@
 name: 'Auto label by title'
 on:
   pull_request:
-    types: [opened]
+    types: [opened, edited]
     branches: [ "main" ]
 
 permissions: {}


### PR DESCRIPTION
The shared auto-label workflow relabels a pull request when its title is edited, but this caller only listens for `opened`, so a corrected title keeps the label the original title produced. Add `edited` to the trigger.